### PR TITLE
Issue #18 : Migrate syncd-vpp and docker-sonic-vpp container image to…

### DIFF
--- a/platform/vpp/docker-sonic-vpp/frr/frr/zebra/zebra.conf.j2
+++ b/platform/vpp/docker-sonic-vpp/frr/frr/zebra/zebra.conf.j2
@@ -6,6 +6,13 @@
 !
 {% endblock banner %}
 !
+{% block fpm %}
+! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
+no fpm use-next-hop-groups
+!
+fpm address 127.0.0.1
+{% endblock fpm %}
+!
 {% include "common/daemons.common.conf.j2" %}
 !
 {% include "zebra.interfaces.conf.j2" %}

--- a/platform/vpp/docker-sonic-vpp/supervisord.conf.j2
+++ b/platform/vpp/docker-sonic-vpp/supervisord.conf.j2
@@ -164,7 +164,7 @@ environment=ASAN_OPTIONS="log_path=/var/log/asan/teammgrd-asan.log{{ asan_extra_
 {% endif %}
 
 [program:zebra]
-command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M fpm
+command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl
 priority=13
 autostart=false
 autorestart=false


### PR DESCRIPTION
… debian bullseye

This fixes an issue zebra config missing in docker-sonic-vpp because of the below fix in the mainline https://github.com/sonic-net/sonic-buildimage/pull/12852

Unit tested static routes update, vrf routes etc.