### PR TITLE
Issue #28 : SONiC-VPP VM image build is failing.

### DIFF
--- a/platform/mkrules/build_debian.sh.patch
+++ b/platform/mkrules/build_debian.sh.patch
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 Cisco and/or its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+diff --git a/build_debian.sh b/build_debian.sh
+index af9fcc7ae..18d3b41ae 100755
+--- a/build_debian.sh
++++ b/build_debian.sh
+@@ -533,6 +533,7 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'setup
+ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'wheel==0.35.1'
+ 
+ # docker Python API package is needed by Ansible docker module as well as some SONiC applications
++sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'urllib3==1.26.15'
+ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docker==5.0.3'
+ 
+ # Install scapy

--- a/sonic-vpp-setup.sh
+++ b/sonic-vpp-setup.sh
@@ -98,3 +98,5 @@ cp $SONIC_SAIREDIS/pyext/py3/Makefile.am ./src/sonic-sairedis/pyext/py3/Makefile
 
 pushd . ; cd ./src/sonic-swss; git apply  $SONIC_SRC/sonic-swss/swss.patch; popd
 
+# Fix docker-py and urllib3 incompatibility issue which breaks the build
+git apply $MKRULES_PATH/build_debian.sh.patch


### PR DESCRIPTION
The build breaks with failure of script generate_shutdown_order.py which queries docker to fetch packages. The incompatility between docker python API and urllib3 causes docker connection failure. Fix is to install the compatible urllib3 py package.