### PR TITLE
Fix Issue #35 : Ethernet interfaces are not created when large number…

### DIFF
--- a/platform/mkrules/src/sonic-sairedis/syncd/scripts/syncd_init_common.sh
+++ b/platform/mkrules/src/sonic-sairedis/syncd/scripts/syncd_init_common.sh
@@ -322,9 +322,20 @@ config_syncd_vs()
     CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
 }
 
+vpp_api_check()
+{
+   VPP_API_SOCK=$1
+   while true
+   do
+      [ -S "$VPP_API_SOCK" ] && vpp_api_test socket-name $VPP_API_SOCK <<< "show_version" 2>/dev/null | grep "version:" && break
+      sleep 1
+   done
+}
+
 config_syncd_vpp()
 {
     CMD_ARGS+=" -p $HWSKU_DIR/sai.profile"
+    vpp_api_check "/run/vpp/api.sock"
 }
 
 config_syncd_soda()

--- a/platform/vpp/docker-sonic-vpp/scripts/vpp_init.sh
+++ b/platform/vpp/docker-sonic-vpp/scripts/vpp_init.sh
@@ -67,6 +67,23 @@ upd_startup "}"
 
 sed -i -e "s,VPP_STARTUP_CONFIG,$STARTUP_CFG,g" $TMP_FILE
 
+PERPORT_BUF=2048
+TOTBUF=$((PERPORT_BUF * IDX))
+
+echo "buffers {" >> $TMP_FILE
+echo "    buffers-per-numa $TOTBUF" >> $TMP_FILE
+echo "    page-size default-hugepage" >> $TMP_FILE
+echo "}" >> $TMP_FILE
+
+if [ "$DPDK_DISABLE" != "y" ]; then
+    if [ $IDX -le 6 ]; then
+	NHPG=12
+    else
+	NHPG=$((IDX * 2))
+    fi
+    echo $NHPG > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+fi
+
 cat $TMP_FILE
 
 /usr/bin/vpp -c ${TMP_FILE}

--- a/platform/vpp/docker-syncd-vpp/scripts/vpp_init.sh
+++ b/platform/vpp/docker-syncd-vpp/scripts/vpp_init.sh
@@ -67,6 +67,23 @@ upd_startup "}"
 
 sed -i -e "s,VPP_STARTUP_CONFIG,$STARTUP_CFG,g" $TMP_FILE
 
+PERPORT_BUF=2048
+TOTBUF=$((PERPORT_BUF * IDX))
+
+echo "buffers {" >> $TMP_FILE
+echo "    buffers-per-numa $TOTBUF" >> $TMP_FILE
+echo "    page-size default-hugepage" >> $TMP_FILE
+echo "}" >> $TMP_FILE
+
+if [ "$DPDK_DISABLE" != "y" ]; then
+    if [ $IDX -le 6 ]; then
+	NHPG=12
+    else
+	NHPG=$((IDX * 2))
+    fi
+    echo $NHPG > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+fi
+
 cat $TMP_FILE
 
 /usr/bin/vpp -c ${TMP_FILE}


### PR DESCRIPTION
… of ports are configured

There two problems with large number of ports configured
1. Timing issue in syncd establishing binary API connection with VPP
2. Default VPP config does not have enough memory to support large number of ports

Timing issue is fixed by making sure VPP API interface is functional. The VPP memory resource is fixed by creating a pool as per the number of ports configured.