### PR TITLE
Fix Issue #40 : IP route multi path based on ECMP

### DIFF
--- a/platform/saivpp/vpplib/Makefile.am
+++ b/platform/saivpp/vpplib/Makefile.am
@@ -57,6 +57,7 @@ libSaiVPP_a_SOURCES = \
 					  SwitchStateBaseRif.cpp \
 					  SwitchStateBaseNbr.cpp \
 					  SwitchStateBaseRoute.cpp \
+					  SwitchStateBaseNexthop.cpp \
 					  SwitchStateBaseMACsec.cpp \
 					  SwitchState.cpp \
 					  TrafficFilterPipes.cpp \

--- a/platform/saivpp/vpplib/SwitchStateBase.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBase.cpp
@@ -186,6 +186,11 @@ sai_status_t SwitchStateBase::create(
         return addIpRoute(serializedObjectId, switch_id, attr_count, attr_list);
     }
 
+    if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER)
+    {
+        return NexthopGrpMemberAdd(serializedObjectId, switch_id, attr_count, attr_list);
+    }
+
     if (object_type == SAI_OBJECT_TYPE_NEIGHBOR_ENTRY)
     {
         return addIpNbr(serializedObjectId, switch_id, attr_count, attr_list);
@@ -433,6 +438,16 @@ sai_status_t SwitchStateBase::remove(
         return removeIpRoute(serializedObjectId);
     }
 
+    if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER)
+    {
+        return NexthopGrpMemberRemove(serializedObjectId);
+    }
+
+    if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP)
+    {
+        return NexthopGrpRemove(serializedObjectId);
+    }
+
     if (object_type == SAI_OBJECT_TYPE_NEIGHBOR_ENTRY)
     {
         return removeIpNbr(serializedObjectId);
@@ -589,6 +604,11 @@ sai_status_t SwitchStateBase::set(
         sai_object_id_t objectId;
         sai_deserialize_object_id(serializedObjectId, objectId);
         return setAclEntry(objectId, attr);
+    }
+
+    if (objectType == SAI_OBJECT_TYPE_ROUTE_ENTRY)
+    {
+        return updateIpRoute(serializedObjectId, attr);
     }
 
     if (objectType == SAI_OBJECT_TYPE_MACSEC_SA)

--- a/platform/saivpp/vpplib/SwitchStateBase.h
+++ b/platform/saivpp/vpplib/SwitchStateBase.h
@@ -29,6 +29,9 @@
 #include <set>
 #include <unordered_set>
 #include <vector>
+#include <list>
+
+#include "SwitchStateBaseNexthop.h"
 
 #define SAI_VPP_FDB_INFO "SAI_VPP_FDB_INFO"
 
@@ -162,7 +165,7 @@ namespace saivpp
 
             virtual sai_status_t refresh_vlan_member_list(
                     _In_ const sai_attr_metadata_t *meta,
-                    _In_ sai_object_id_t vlan_id);
+                   _In_ sai_object_id_t vlan_id);
 
             virtual sai_status_t refresh_port_list(
                     _In_ const sai_attr_metadata_t *meta);
@@ -694,6 +697,30 @@ namespace saivpp
             bool nbr_active = false;
 	    std::map<std::string, std::string> m_intf_prefix_map;
 
+            std::map<sai_object_id_t, std::list<sai_object_id_t>> m_nxthop_grp_mbr_map;
+
+        protected:
+            sai_status_t NexthopGrpRemove(
+                _In_ const std::string &serializedObjectId);
+
+            sai_status_t NexthopGrpMemberRemove(
+                _In_ const std::string &serializedObjectId);
+
+            sai_status_t NexthopGrpMemberAdd(
+                _In_ const std::string &serializedObjectId,
+                _In_ sai_object_id_t switch_id,
+                _In_ uint32_t attr_count,
+                _In_ const sai_attribute_t *attr_list);
+
+            sai_status_t IpRouteNexthopGroupEntry(
+                _In_ sai_object_id_t next_hop_grp_oid,
+                _Out_ nexthop_grp_config_t **nxthop_group);
+
+            sai_status_t IpRouteNexthopEntry(
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list,
+		    _Out_ nexthop_grp_config_t **nxthop_group_cfg);
+
         protected:
 	    sai_status_t createRouterif(
 		    _In_ sai_object_id_t object_id,
@@ -781,16 +808,14 @@ namespace saivpp
                     _In_ const sai_attribute_t *attr_list);
             sai_status_t removeIpRoute(
 		    _In_ const std::string &serializedObjectId);
-            sai_status_t IpRouteNexthopEntry(
-                    _In_ uint32_t attr_count,
-                    _In_ const sai_attribute_t *attr_list,
-                    sai_ip_address_t *ip_address,
-                    sai_object_id_t *next_rif_oid);
             sai_status_t IpRouteAddRemove(
                     _In_ const std::string &serializedObjectId,
                     _In_ uint32_t attr_count,
                     _In_ const sai_attribute_t *attr_list,
                     _In_ bool is_add);
+            sai_status_t updateIpRoute(
+                    _In_ const std::string &serializedObjectId,
+                    _In_ const sai_attribute_t *attr_list);
 
 
             int vpp_add_ip_vrf(_In_ sai_object_id_t objectId, uint32_t vrf_id);

--- a/platform/saivpp/vpplib/SwitchStateBaseNexthop.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseNexthop.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SwitchStateBase.h"
+
+#include "swss/logger.h"
+#include "swss/exec.h"
+#include "swss/converter.h"
+
+#include "meta/sai_serialize.h"
+#include "meta/NotificationPortStateChange.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/in.h>
+
+#include "SwitchStateBaseNexthop.h"
+#include "SwitchStateBaseUtils.h"
+#include "vppxlate/SaiVppXlate.h"
+
+#include <list>
+
+using namespace saivpp;
+
+sai_status_t SwitchStateBase::IpRouteNexthopGroupEntry(
+    _In_ sai_object_id_t next_hop_grp_oid,
+    _Out_ nexthop_grp_config_t **nxthop_group)
+{
+    sai_attribute_t attr;
+    int32_t group_type;
+
+    attr.id = SAI_NEXT_HOP_GROUP_ATTR_TYPE;
+
+    if (get(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, next_hop_grp_oid, 1, &attr) != SAI_STATUS_SUCCESS) {
+        return SAI_STATUS_SUCCESS;
+    }
+    if (attr.value.s32 != SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP &&
+        attr.value.s32 != SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_ORDERED_ECMP) {
+	return SAI_STATUS_SUCCESS;
+    }
+    group_type = attr.value.s32;
+
+    auto it = m_nxthop_grp_mbr_map.find(next_hop_grp_oid);
+
+    std::list<sai_object_id_t> member_list;
+
+    if (it == m_nxthop_grp_mbr_map.end()) {
+        SWSS_LOG_WARN("Nexthop member list missing for Nexthop group %s",
+                      sai_serialize_object_id(next_hop_grp_oid).c_str());
+        return SAI_STATUS_FAILURE;
+    } else {
+        member_list = it->second;
+        if (!member_list.size()) {
+            SWSS_LOG_WARN("Nexthop member list empty for Nexthop group %s",
+                          sai_serialize_object_id(next_hop_grp_oid).c_str());
+            return SAI_STATUS_FAILURE;
+        }
+    }
+
+    uint32_t next_hop_weight, next_hop_sequence;
+    sai_object_id_t next_hop_oid, rif_oid;
+    sai_ip_address_t ip_address;
+    nexthop_grp_config_t *nxthop_grp_cfg;
+
+    size_t grp_size = sizeof(nexthop_grp_config_t) + (member_list.size() * sizeof(nexthop_grp_member_t));
+
+    nxthop_grp_cfg = (nexthop_grp_config_t *) calloc(1, grp_size);
+    if (nxthop_grp_cfg == NULL) {
+        return SAI_STATUS_FAILURE;
+    }
+    nexthop_grp_member_t *nxt_grp_member;
+
+    nxt_grp_member = nxthop_grp_cfg->grp_members;
+
+    for (sai_object_id_t member_oid : member_list) {
+        next_hop_weight = 1;
+        next_hop_sequence = 0;
+        rif_oid = 0;
+
+        attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID;
+        if (get(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER, member_oid, 1, &attr) == SAI_STATUS_SUCCESS)
+        {
+            next_hop_oid = attr.value.oid;
+        } else {
+            SWSS_LOG_ERROR("Nexthop oid missing for member %s",
+			   sai_serialize_object_id(member_oid).c_str());
+            free(nxthop_grp_cfg);
+            return SAI_STATUS_FAILURE;
+        }
+        attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT;
+        if (get(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER, member_oid, 1, &attr) == SAI_STATUS_SUCCESS)
+        {
+            next_hop_weight = attr.value.u32;
+        }
+        attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_SEQUENCE_ID;
+        if (get(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER, member_oid, 1, &attr) == SAI_STATUS_SUCCESS)
+        {
+            next_hop_sequence = attr.value.u32;
+        }
+
+        attr.id = SAI_NEXT_HOP_ATTR_IP;
+        if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS)
+        {
+            ip_address = attr.value.ipaddr;
+        }
+
+        attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
+        if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS)
+        {
+            rif_oid = attr.value.oid;
+        }
+
+        nxt_grp_member->addr = ip_address;
+        nxt_grp_member->seq_id = next_hop_sequence;
+        nxt_grp_member->weight = next_hop_weight;
+        nxt_grp_member->rif_oid = rif_oid;
+
+        nxt_grp_member++;
+    }
+
+    nxthop_grp_cfg->grp_type = group_type;
+    nxthop_grp_cfg->nmembers = (uint32_t) member_list.size();
+
+    *nxthop_group = nxthop_grp_cfg;
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchStateBase::NexthopGrpMemberAdd(
+        _In_ const std::string &serializedObjectId,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+    sai_status_t                 status;
+    const sai_attribute_value_t  *next_hop_grp;
+    sai_object_id_t              next_hop_grp_oid;
+    uint32_t                     next_hop_index;
+
+    status = find_attrib_in_list(attr_count, attr_list, SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID,
+                                 &next_hop_grp, &next_hop_index);
+    if (status != SAI_STATUS_SUCCESS) {
+	return status;
+    }
+    next_hop_grp_oid = next_hop_grp->oid;
+
+    if (SAI_OBJECT_TYPE_NEXT_HOP_GROUP != sai_object_type_query(next_hop_grp_oid)) {
+	return SAI_STATUS_SUCCESS;
+    }
+    sai_object_id_t member_oid;
+
+    sai_deserialize_object_id(serializedObjectId, member_oid);
+    auto it = m_nxthop_grp_mbr_map.find(next_hop_grp_oid);
+
+    if (it == m_nxthop_grp_mbr_map.end()) {
+        std::list<sai_object_id_t> member_list;
+
+        member_list = { member_oid };
+        m_nxthop_grp_mbr_map[next_hop_grp_oid] = member_list;
+    } else {
+        std::list<sai_object_id_t>& member_list = it->second;
+
+        member_list.push_back(member_oid);
+    }
+    SWSS_LOG_NOTICE("Nextop group member %s added to nexthop group %s",
+		    serializedObjectId.c_str(), sai_serialize_object_id(next_hop_grp_oid).c_str());
+
+    return create_internal(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER, serializedObjectId,
+			   switch_id, attr_count, attr_list);
+}
+
+sai_status_t SwitchStateBase::NexthopGrpMemberRemove(
+        _In_ const std::string &serializedObjectId)
+{
+    SWSS_LOG_ENTER();
+    sai_object_id_t member_oid, next_hop_grp_oid;
+
+    sai_deserialize_object_id(serializedObjectId, member_oid);
+
+    sai_attribute_t attr;
+
+    attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID;
+
+    CHECK_STATUS(get(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER, member_oid, 1, &attr));
+
+    next_hop_grp_oid = attr.value.oid;
+
+    auto it = m_nxthop_grp_mbr_map.find(next_hop_grp_oid);
+
+    if (it == m_nxthop_grp_mbr_map.end()) {
+        SWSS_LOG_WARN("Nextop member list not found for nexthop group %s", serializedObjectId.c_str());
+    } else {
+        std::list<sai_object_id_t>& member_list = it->second;
+
+        member_list.remove(member_oid);
+	SWSS_LOG_NOTICE("Nextop group member %s removed from nexthop group %s",
+			serializedObjectId.c_str(), sai_serialize_object_id(next_hop_grp_oid).c_str());
+    }
+
+    return remove_internal(SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER, serializedObjectId);
+}
+
+sai_status_t SwitchStateBase::NexthopGrpRemove(
+        _In_ const std::string &serializedObjectId)
+{
+    SWSS_LOG_ENTER();
+    sai_object_id_t next_hop_grp_oid;
+
+    sai_deserialize_object_id(serializedObjectId, next_hop_grp_oid);
+
+    auto it = m_nxthop_grp_mbr_map.find(next_hop_grp_oid);
+
+    if (it == m_nxthop_grp_mbr_map.end()) {
+        SWSS_LOG_DEBUG("Nextop member list not found for nexthop group %s", serializedObjectId.c_str());
+    } else {
+        std::list<sai_object_id_t>& member_list = it->second;
+
+        member_list.clear();
+        m_nxthop_grp_mbr_map.erase(it);
+
+	SWSS_LOG_NOTICE("Nextop group %s removed", serializedObjectId.c_str());
+    }
+
+    return remove_internal(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, serializedObjectId);
+}
+
+sai_status_t SwitchStateBase::IpRouteNexthopEntry(
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list,
+        _Out_ nexthop_grp_config_t **nxthop_group_cfg)
+{
+    sai_status_t                 status;
+    const sai_attribute_value_t  *next_hop;
+    sai_object_id_t              next_hop_oid;
+    uint32_t                     next_hop_index;
+    sai_ip_address_t ip_address;
+    sai_object_id_t nexthop_rif_oid = 0;
+
+    status = find_attrib_in_list(attr_count, attr_list, SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID,
+                                 &next_hop, &next_hop_index);
+    if (status != SAI_STATUS_SUCCESS) {
+	return status;
+    }
+    next_hop_oid = next_hop->oid;
+
+    if (SAI_OBJECT_TYPE_NEXT_HOP != sai_object_type_query(next_hop_oid)) {
+	return SAI_STATUS_FAILURE;
+    }
+    sai_attribute_t attr;
+    attr.id = SAI_NEXT_HOP_ATTR_TYPE;
+
+    CHECK_STATUS(get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr));
+    if (attr.value.s32 != SAI_NEXT_HOP_TYPE_IP) {
+	return SAI_STATUS_SUCCESS;
+    }
+    attr.id = SAI_NEXT_HOP_ATTR_IP;
+    if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS)
+    {
+	ip_address = attr.value.ipaddr;
+    } else {
+        SWSS_LOG_ERROR("IP address missing in nexthop %s", sai_serialize_object_id(next_hop_oid).c_str());
+        return SAI_STATUS_SUCCESS;
+    }
+    attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
+    if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS)
+    {
+	nexthop_rif_oid = attr.value.oid;
+    }
+
+    nexthop_grp_config_t *nxthop_group;
+
+    nxthop_group = (nexthop_grp_config_t *)
+      calloc(1, sizeof(nexthop_grp_config_t) + (1 * sizeof(nexthop_grp_member_t)));
+    if (!nxthop_group) {
+        return SAI_STATUS_FAILURE;
+    }
+
+    nexthop_grp_member_t *nxt_grp_member;
+
+    nxthop_group->nmembers = 1;
+    nxt_grp_member = nxthop_group->grp_members;
+
+    nxt_grp_member->addr = ip_address;
+    nxt_grp_member->weight = 1;
+    nxt_grp_member->seq_id = 0;
+    nxt_grp_member->rif_oid = nexthop_rif_oid;
+
+    *nxthop_group_cfg = nxthop_group;
+
+    return SAI_STATUS_SUCCESS;
+}

--- a/platform/saivpp/vpplib/SwitchStateBaseNexthop.h
+++ b/platform/saivpp/vpplib/SwitchStateBaseNexthop.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _SWITCHSTATEBASENEXTHOP_H_
+#define _SWITCHSTATEBASENEXTHOP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct nexthop_grp_member_ {
+    sai_ip_address_t addr;
+    sai_object_id_t rif_oid;
+    uint32_t weight;
+    uint32_t seq_id;
+} nexthop_grp_member_t;
+
+typedef struct nexthop_grp_config_ {
+    int32_t grp_type;
+    uint32_t nmembers;
+
+    /* Must be the last variable */
+    nexthop_grp_member_t grp_members[0];
+} nexthop_grp_config_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/saivpp/vpplib/SwitchStateBaseRoute.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseRoute.cpp
@@ -28,6 +28,8 @@
 #include <net/if.h>
 #include <netinet/in.h>
 
+#include "SwitchStateBaseNexthop.h"
+
 #include "vppxlate/SaiVppXlate.h"
 
 #include "SwitchStateBaseUtils.h"
@@ -66,52 +68,14 @@ void create_route_prefix_entry (
     }
 }
 
-sai_status_t SwitchStateBase::IpRouteNexthopEntry(
-        _In_ uint32_t attr_count,
-        _In_ const sai_attribute_t *attr_list,
-        sai_ip_address_t *ip_address,
-        sai_object_id_t *nexthop_rif_oid)
-{
-    sai_status_t                 status;
-    const sai_attribute_value_t  *next_hop;
-    sai_object_id_t              next_hop_oid;
-    uint32_t                     next_hop_index;
-
-    status = find_attrib_in_list(attr_count, attr_list, SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID, &next_hop, &next_hop_index);
-    if (status != SAI_STATUS_SUCCESS) {
-	return status;
-    }
-    next_hop_oid = next_hop->oid;
-
-    if (SAI_OBJECT_TYPE_NEXT_HOP != sai_object_type_query(next_hop_oid)) {
-	return SAI_STATUS_FAILURE;
-    }
-    sai_attribute_t attr;
-    attr.id = SAI_NEXT_HOP_ATTR_TYPE;
-
-    CHECK_STATUS(get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr));
-    if (attr.value.s32 != SAI_NEXT_HOP_TYPE_IP) {
-	return SAI_STATUS_SUCCESS;
-    }
-    attr.id = SAI_NEXT_HOP_ATTR_IP;
-    if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS)
-    {
-	*ip_address = attr.value.ipaddr;
-    }
-    attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
-    if (get(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_oid, 1, &attr) == SAI_STATUS_SUCCESS)
-    {
-	*nexthop_rif_oid = attr.value.oid;
-    }
-    return SAI_STATUS_SUCCESS;
-}
-
 void create_vpp_nexthop_entry (
-    sai_ip_address_t *ip_address,
+    nexthop_grp_member_t *nxt_grp_member,
     const char *hwif_name,
     vpp_nexthop_type_e type,
     vpp_ip_nexthop_t *vpp_nexthop)
 {
+    sai_ip_address_t *ip_address = &nxt_grp_member->addr;
+
     switch (ip_address->addr_family) {
     case SAI_IP_ADDR_FAMILY_IPV4:
     {
@@ -134,7 +98,8 @@ void create_vpp_nexthop_entry (
     }
     vpp_nexthop->type = type;
     vpp_nexthop->hwif_name = hwif_name;
-    vpp_nexthop->weight = 1;
+    vpp_nexthop->weight = (uint8_t) nxt_grp_member->weight;
+    vpp_nexthop->preference = (uint8_t) nxt_grp_member->seq_id;
 }
 
 sai_status_t SwitchStateBase::IpRouteAddRemove(
@@ -157,8 +122,6 @@ sai_status_t SwitchStateBase::IpRouteAddRemove(
     }
     next_hop_oid = next_hop->oid;
 
-    sai_ip_address_t nhp_ip_address;
-    sai_object_id_t nexthop_rif_oid;
     sai_route_entry_t route_entry;
     const char *hwif_name = NULL;
     vpp_nexthop_type_e nexthop_type = VPP_NEXTHOP_NORMAL;
@@ -166,20 +129,31 @@ sai_status_t SwitchStateBase::IpRouteAddRemove(
 
     sai_deserialize_route_entry(serializedObjectId, route_entry);
 
+    nexthop_grp_config_t *nxthop_group = NULL;
+
     if (SAI_OBJECT_TYPE_ROUTER_INTERFACE == sai_object_type_query(next_hop_oid))
     {
         // vpp_add_del_intf_ip_addr(route_entry.destination, next_hop_oid, is_add);
     }
     else if (SAI_OBJECT_TYPE_PORT == sai_object_type_query(next_hop_oid))
     {
-	status = find_attrib_in_list(attr_count, attr_list, SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION, &next_hop, &next_hop_index);
+	status = find_attrib_in_list(attr_count, attr_list, SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION,
+                                     &next_hop, &next_hop_index);
 	if (status == SAI_STATUS_SUCCESS && SAI_PACKET_ACTION_FORWARD == next_hop->s32) {
 	    vpp_add_del_intf_ip_addr_norif(serializedObjectId, route_entry, is_add);    
 	}
     }
     else if (SAI_OBJECT_TYPE_NEXT_HOP == sai_object_type_query(next_hop_oid))
     {
-	if (IpRouteNexthopEntry(attr_count, attr_list, &nhp_ip_address, &nexthop_rif_oid) == SAI_STATUS_SUCCESS)
+
+	if (IpRouteNexthopEntry(attr_count, attr_list, &nxthop_group) == SAI_STATUS_SUCCESS)
+        {
+	    config_ip_route = true;
+	}
+    }
+    else if (SAI_OBJECT_TYPE_NEXT_HOP_GROUP == sai_object_type_query(next_hop_oid))
+    {
+	if (IpRouteNexthopGroupEntry(next_hop_oid, &nxthop_group) == SAI_STATUS_SUCCESS)
         {
 	    config_ip_route = true;
 	}
@@ -196,24 +170,39 @@ sai_status_t SwitchStateBase::IpRouteAddRemove(
 	} else {
 	    vrf_id = vrf->m_vrf_id;
 	}
-	vpp_ip_route_t *ip_route = (vpp_ip_route_t *) calloc(1, sizeof(vpp_ip_route_t) + sizeof(vpp_ip_nexthop_t));
+	vpp_ip_route_t *ip_route = (vpp_ip_route_t *)
+            calloc(1, sizeof(vpp_ip_route_t) + (nxthop_group->nmembers * sizeof(vpp_ip_nexthop_t)));
 	if (!ip_route) {
 	    return SAI_STATUS_FAILURE;
 	}
 	create_route_prefix_entry(&route_entry, ip_route);
 	ip_route->vrf_id = vrf_id;
-	ip_route->is_multipath = false;
+	ip_route->is_multipath = (nxthop_group->nmembers > 1) ? true : false;
 
-	create_vpp_nexthop_entry(&nhp_ip_address, hwif_name, nexthop_type,  &ip_route->nexthop[0]);
-	ip_route->nexthop_cnt = 1;
+        nexthop_grp_member_t *nxt_grp_member;
+
+        nxt_grp_member = nxthop_group->grp_members;
+
+        size_t i;
+        for (i = 0; i < nxthop_group->nmembers; i++) {
+            create_vpp_nexthop_entry(nxt_grp_member, hwif_name, nexthop_type,  &ip_route->nexthop[i]);
+            nxt_grp_member++;
+        }
+        ip_route->nexthop_cnt = nxthop_group->nmembers;
 
 	init_vpp_client();
 
 	ret = ip_route_add_del(ip_route, is_add);
-	free(ip_route);
 
 	SWSS_LOG_NOTICE("%s ip route in VPP %s status %d table %u", (is_add ? "Add" : "Remove"),
 			serializedObjectId.c_str(), ret, vrf_id);
+	SWSS_LOG_NOTICE("%s route nexthop type %s count %u", (is_add ? "Add" : "Remove"),
+			sai_serialize_object_type(sai_object_type_query(next_hop_oid)).c_str(),
+			nxthop_group->nmembers);
+
+	free(ip_route);
+        free(nxthop_group);
+
     } else {
 	SWSS_LOG_NOTICE("Ignoring VPP ip route %s", serializedObjectId.c_str());
     }
@@ -234,6 +223,39 @@ sai_status_t SwitchStateBase::addIpRoute(
     }
 
     CHECK_STATUS(create_internal(SAI_OBJECT_TYPE_ROUTE_ENTRY, serializedObjectId, switch_id, attr_count, attr_list));
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t SwitchStateBase::updateIpRoute(
+        _In_ const std::string &serializedObjectId,
+        _In_ const sai_attribute_t *attr)
+{
+    SWSS_LOG_ENTER();
+
+    if (is_ip_nbr_active() == true) {
+        SWSS_LOG_NOTICE("ip route entry update %s", serializedObjectId.c_str());
+
+        sai_attribute_t attr_list[2];
+
+	attr_list[0].id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+
+	if (get(SAI_OBJECT_TYPE_ROUTE_ENTRY, serializedObjectId, 1, &attr_list[0]) == SAI_STATUS_SUCCESS) {
+	    uint32_t attr_count = 1;
+
+	    attr_list[1].id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+	    if (get(SAI_OBJECT_TYPE_ROUTE_ENTRY, serializedObjectId, 1, &attr_list[1]) == SAI_STATUS_SUCCESS)
+	    {
+		attr_count++;
+	    }
+
+	    IpRouteAddRemove(serializedObjectId, attr_count, attr_list, false);
+	}
+
+	IpRouteAddRemove(serializedObjectId, 1, attr, true);
+    }
+
+    set_internal(SAI_OBJECT_TYPE_ROUTE_ENTRY, serializedObjectId, attr);
 
     return SAI_STATUS_SUCCESS;
 }

--- a/platform/saivpp/vpplib/vppxlate/SaiVppXlate.h
+++ b/platform/saivpp/vpplib/vppxlate/SaiVppXlate.h
@@ -39,6 +39,7 @@ extern "C" {
 	vpp_ip_addr_t addr;
         const char *hwif_name;
 	uint8_t weight;
+        uint8_t preference;
 	vpp_nexthop_type_e type;
         uint32_t flags;
     } vpp_ip_nexthop_t;
@@ -51,6 +52,17 @@ extern "C" {
         unsigned int nexthop_cnt;
         vpp_ip_nexthop_t nexthop[0];
     } vpp_ip_route_t;
+
+    typedef enum {
+        VPP_IP_API_FLOW_HASH_SRC_IP = 1,
+        VPP_IP_API_FLOW_HASH_DST_IP = 2,
+        VPP_IP_API_FLOW_HASH_SRC_PORT = 4,
+        VPP_IP_API_FLOW_HASH_DST_PORT = 8,
+        VPP_IP_API_FLOW_HASH_PROTO = 16,
+        VPP_IP_API_FLOW_HASH_REVERSE = 32,
+        VPP_IP_API_FLOW_HASH_SYMETRIC = 64,
+        VPP_IP_API_FLOW_HASH_FLOW_LABEL = 128,
+    } vpp_ip_flow_hash_mask_e;
 
     extern int init_vpp_client();
     extern int refresh_interfaces_list();
@@ -71,6 +83,7 @@ extern "C" {
     extern int ip6_nbr_add_del(const char *hwif_name, struct sockaddr_in6 *addr,
 			       bool is_static, uint8_t *mac, bool is_add);
     extern int ip_route_add_del(vpp_ip_route_t *prefix, bool is_add);
+    extern int vpp_ip_flow_hash_set(uint32_t vrf_id, uint32_t mask, int addr_family);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The NEXTHOP GROUP configuration is done in Make-Before-Break way by SONiC. Currently only (Un)Ordered ECMP supported. The route config comes as an update for a nexthop group.

Unit testing done with 3 nexthops for a given route and verified.