### PR TITLE
Fix Issue #46 - Build broken by mainline sonic

### DIFF
--- a/sonic-vpp-setup.sh
+++ b/sonic-vpp-setup.sh
@@ -25,9 +25,9 @@ VPPLIBPATH=$PWD/platform/saivpp/vpplib
 cd ./build/sonic-buildimage
 
 # Below is the build label information
-# 285104	20230601.6	master	Azure.sonic-buildimage.official.vs	succeeded	2023-06-01T08:18:54	2023-06-01T13:21:09	8b151d81c7
-WORKING_LABEL=8b151d81c7
 SONIC_CHECKOUT_LABEL=${SONIC_CHECKOUT_LABEL:=$WORKING_LABEL}
+# 298188	20230620.7	master	Azure.sonic-buildimage.official.vs	succeeded	2023-06-20T08:10:14	2023-06-20T13:04:10	c81c368b10
+WORKING_LABEL=c81c368b10
 git checkout $SONIC_CHECKOUT_LABEL
 
 make init


### PR DESCRIPTION
Move to latest label of sonic-buildimage which has the fix.