### PR TITLE
1) Properly migrated from CREATE_LOOPBACK handler to CREATE_LOOPBACK_INSTANCE handler

### DIFF
--- a/platform/saivpp/vpplib/SwitchStateBase.h
+++ b/platform/saivpp/vpplib/SwitchStateBase.h
@@ -758,8 +758,8 @@ namespace saivpp
                     _In_ bool is_add);
             sai_status_t process_interface_loopback (
                     _In_ const std::string &serializedObjectId,
-                    _In_ bool is_add,
-                    _In_ bool &isLoopback);
+                    _In_ bool &isLoopback,
+                    _In_ bool is_add);
             sai_status_t vpp_add_del_lpb_intf_ip_addr (
                     _In_ const std::string &serializedObjectId,
                     _In_ bool is_add);

--- a/platform/saivpp/vpplib/SwitchStateBase.h
+++ b/platform/saivpp/vpplib/SwitchStateBase.h
@@ -761,7 +761,6 @@ namespace saivpp
                     _In_ bool is_add,
                     _In_ bool &isLoopback);
             sai_status_t vpp_add_del_lpb_intf_ip_addr (
-                    _In_ std::string destinationIP,
                     _In_ const std::string &serializedObjectId,
                     _In_ bool is_add);
 

--- a/platform/saivpp/vpplib/SwitchStateBaseRif.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseRif.cpp
@@ -801,8 +801,8 @@ sai_status_t SwitchStateBase::vpp_add_del_intf_ip_addr_norif (
 
 sai_status_t SwitchStateBase::process_interface_loopback (
    _In_ const std::string &serializedObjectId,
-   _In_ bool is_add,
-   _In_ bool &isLoopback)
+   _In_ bool &isLoopback,
+   _In_ bool is_add)
 {
     SWSS_LOG_ENTER();
 

--- a/platform/saivpp/vpplib/SwitchStateBaseRif.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseRif.cpp
@@ -805,26 +805,31 @@ sai_status_t SwitchStateBase::process_interface_loopback (
    _In_ bool &isLoopback)
 {
     SWSS_LOG_ENTER();
-    isLoopback = false;
 
     sai_route_entry_t route_entry;
     sai_deserialize_route_entry(serializedObjectId, route_entry);
-
     std::string destinationIP = extractDestinationIP(serializedObjectId);
+    std::string interfaceName;
 
-    std::string interfaceName = get_intf_name_for_prefix(route_entry);
+    if (is_add)
+    {
+        interfaceName = get_intf_name_for_prefix(route_entry);
+    } else
+    {
+        interfaceName = lpbIpToHostIfMap[destinationIP];
+    }
+
     isLoopback = (interfaceName.find("Loopback") != std::string::npos);
-    SWSS_LOG_NOTICE("destination_ip:%s interfaceName:%s isLoopback:%u", destinationIP.c_str(), interfaceName.c_str(), isLoopback);
+    SWSS_LOG_NOTICE("interfaceName:%s isLoopback:%u", interfaceName.c_str(), isLoopback);
 
     if (isLoopback) {
-        vpp_add_del_lpb_intf_ip_addr(destinationIP, serializedObjectId, is_add);
+        vpp_add_del_lpb_intf_ip_addr(serializedObjectId, is_add);
     }
 
     return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t SwitchStateBase::vpp_add_del_lpb_intf_ip_addr (
-    _In_ std::string destinationIP,
     _In_ const std::string &serializedObjectId,
     _In_ bool is_add)
 {
@@ -833,6 +838,7 @@ sai_status_t SwitchStateBase::vpp_add_del_lpb_intf_ip_addr (
     sai_route_entry_t route_entry;
     sai_deserialize_route_entry(serializedObjectId, route_entry);
     std::string ip_prefix_str;
+    std::string destinationIP = extractDestinationIP(serializedObjectId);
 
     if (is_add)
     {

--- a/platform/saivpp/vpplib/SwitchStateBaseRoute.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseRoute.cpp
@@ -218,7 +218,7 @@ sai_status_t SwitchStateBase::addIpRoute(
 {
     SWSS_LOG_ENTER();
     bool isLoopback = false;
-    isLoopback = process_interface_loopback(serializedObjectId, true, isLoopback);
+    process_interface_loopback(serializedObjectId, isLoopback, true);
 
     if (isLoopback == false && is_ip_nbr_active() == true)
     {
@@ -268,7 +268,7 @@ sai_status_t SwitchStateBase::removeIpRoute(
 {
     SWSS_LOG_ENTER();
     bool isLoopback = false;
-    isLoopback = process_interface_loopback(serializedObjectId, false, isLoopback);
+    process_interface_loopback(serializedObjectId, isLoopback, false);
 
     if (isLoopback == false && is_ip_nbr_active() == true)
     {

--- a/platform/saivpp/vpplib/vppxlate/SaiVppXlate.c
+++ b/platform/saivpp/vpplib/vppxlate/SaiVppXlate.c
@@ -299,7 +299,7 @@ vl_api_sw_interface_details_t_handler (vl_api_sw_interface_details_t *mp)
 
 static void
 vl_api_create_loopback_instance_reply_t_handler (
-    vl_api_create_loopback_reply_t * msg)
+    vl_api_create_loopback_instance_reply_t * msg)
 {
     vat_main_t *vam = &vat_main;
 
@@ -712,13 +712,13 @@ static int __create_loopback_instance (vat_main_t *vam, u32 instance)
 
     __plugin_msg_base = interface_msg_id_base;
 
-    M (CREATE_LOOPBACK, mp);
+    M (CREATE_LOOPBACK_INSTANCE, mp);
     mp->is_specified = true;
     mp->user_instance = instance;
     /* Set MAC address */
     memcpy(mp->mac_address, mac_address, sizeof(mac_address));
 
-    /* create_loopback interfaces from vnet/interface_cli.c */
+    /* create loopback interfaces from vnet/interface_cli.c */
     S (mp);
 
     W (ret);


### PR DESCRIPTION
1) Properly migrated from CREATE_LOOPBACK handler to CREATE_LOOPBACK_INSTANCE handler

2) The existing appraoch of get_intf_name_for_prefix is not working in
   the case of removing the Loopback interface as the host is removing
it before the function gets it.  So, for the "loopback remove" path getting the interface_name from the stored entry.