### PR TITLE
Fixes issue #62 - SONiC-VPP VM image build failure

### DIFF
--- a/platform/mkrules/rules/sairedis.mk
+++ b/platform/mkrules/rules/sairedis.mk
@@ -64,7 +64,7 @@ $(LIBSAIMETADATA_DBG)_RDEPENDS += $(LIBSAIMETADATA)
 $(eval $(call add_derived_package,$(LIBSAIREDIS),$(LIBSAIMETADATA_DBG)))
 
 ifeq ($(ENABLE_PY2_MODULES), n)
-    $(LIBSAIREDIS)_BUILD_ENV += DEB_BUILD_PROFILES=nopython2
+    $(LIBSAIREDIS)_DEB_BUILD_PROFILES += nopython2
 endif
 
 # The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}

--- a/sonic-vpp-setup.sh
+++ b/sonic-vpp-setup.sh
@@ -26,8 +26,9 @@ cd ./build/sonic-buildimage
 
 # Below is the build label information
 SONIC_CHECKOUT_LABEL=${SONIC_CHECKOUT_LABEL:=$WORKING_LABEL}
-# 310697	20230708.7	master	Azure.sonic-buildimage.official.vs	succeeded	2023-07-08T08:24:32	2023-07-08T13:23:20	f6282b8259
-WORKING_LABEL=f6282b8259
+
+#320487	20230721.7	master	Azure.sonic-buildimage.official.vs	succeeded	2023-07-21T08:07:21	2023-07-21T13:03:56	287056110e
+WORKING_LABEL=287056110e
 git checkout $SONIC_CHECKOUT_LABEL
 
 make init


### PR DESCRIPTION
The label is moved to latest one to get sonic-platform-deamons test_pcid failure fixed. Also fixed the new DEB_PROFILE env variable for sairedis which broke the sairedis build.

https://github.com/sonic-net/sonic-buildimage/commit/371c3a0be5c046eed2a98ffac108aaee547718f4