### PR TITLE
Fixes #67 - bgpcfgd crashing during boot

### DIFF
--- a/platform/mkrules/files/scripts/sonic_vpp_cfg.sh
+++ b/platform/mkrules/files/scripts/sonic_vpp_cfg.sh
@@ -174,9 +174,9 @@ done
 echo "Writing syncd_vpp_env contents"
 echo "VPP_PORT_LIST=$NETPORTS" > $VPP_ENV_FILE
 
-if [ "$NO_LINUX_NL" == "y" ]; then
-    echo "NO_LINUX_NL=y" >> $VPP_ENV_FILE
-fi
+NO_LINUX_NL=${NO_LINUX_NL:="y"}
+
+echo "NO_LINUX_NL=$NO_LINUX_NL" >> $VPP_ENV_FILE
 
 if [ "$VPP_CONF_DB" == "y" ]; then
     echo "VPP_CONF_DB=y" >> $VPP_ENV_FILE

--- a/platform/vpp/docker-sonic-vpp/conf/constants.yml
+++ b/platform/vpp/docker-sonic-vpp/conf/constants.yml
@@ -4,6 +4,7 @@ constants:
     "2" : 65433
   bgp:
     traffic_shift_community: 12345:12345
+    sentinel_community: 12345:12346
     families:
       - ipv4
       - ipv6
@@ -58,3 +59,7 @@ constants:
         enabled: true
         db_table: "BGP_VOQ_CHASSIS_NEIGHBOR"
         template_dir: "voq_chassis"
+      sentinels: # peer_type
+        enabled: true
+        db_table: "BGP_SENTINELS"
+        template_dir: "sentinels"

--- a/platform/vpp/docker-sonic-vpp/frr/frr/bgpd/templates/sentinels/instance.conf.j2
+++ b/platform/vpp/docker-sonic-vpp/frr/frr/bgpd/templates/sentinels/instance.conf.j2
@@ -1,0 +1,31 @@
+!
+! template: bgpd/templates/sentinels/instance.conf.j2
+!
+  neighbor {{ bgp_session['name'] }} peer-group
+  neighbor {{ bgp_session['name'] }} remote-as {{ bgp_asn }}
+{% if bgp_session['src_address'] is defined %}
+  neighbor {{ bgp_session['name'] }} update-source {{ bgp_session['src_address'] | ip }}
+{% endif %}
+{% for ip_range in bgp_session['ip_range'].split(',') %}
+  bgp listen range {{ ip_range }} peer-group {{ bgp_session['name'] }}
+{% endfor %}
+!
+  address-family ipv4
+    neighbor {{ bgp_session['name'] }} activate
+    neighbor {{ bgp_session['name'] }} addpath-tx-all-paths
+    neighbor {{ bgp_session['name'] }} soft-reconfiguration inbound
+    neighbor {{ bgp_session['name'] }} route-map FROM_BGP_SENTINEL in
+    neighbor {{ bgp_session['name'] }} route-map TO_BGP_SENTINEL out
+    neighbor {{ bgp_session['name'] }} maximum-prefix 200
+  exit-address-family
+  address-family ipv6
+    neighbor {{ bgp_session['name'] }} activate
+    neighbor {{ bgp_session['name'] }} addpath-tx-all-paths
+    neighbor {{ bgp_session['name'] }} soft-reconfiguration inbound
+    neighbor {{ bgp_session['name'] }} route-map FROM_BGP_SENTINEL in
+    neighbor {{ bgp_session['name'] }} route-map TO_BGP_SENTINEL out
+    neighbor {{ bgp_session['name'] }} maximum-prefix 200
+  exit-address-family
+!
+! end of template: bgpd/templates/sentinels/instance.conf.j2
+!

--- a/platform/vpp/docker-sonic-vpp/frr/frr/bgpd/templates/sentinels/peer-group.conf.j2
+++ b/platform/vpp/docker-sonic-vpp/frr/frr/bgpd/templates/sentinels/peer-group.conf.j2
@@ -1,0 +1,7 @@
+!
+! template: bgpd/templates/sentinels/peer-group.conf.j2
+!
+! nothing is here
+!
+! end of template: bgpd/templates/sentinels/peer-group.conf.j2
+!

--- a/platform/vpp/docker-sonic-vpp/frr/frr/bgpd/templates/sentinels/policies.conf.j2
+++ b/platform/vpp/docker-sonic-vpp/frr/frr/bgpd/templates/sentinels/policies.conf.j2
@@ -1,0 +1,16 @@
+!
+! template: bgpd/templates/sentinels/policies.conf.j2
+!
+{% if constants.bgp.sentinel_community is defined %}
+bgp community-list standard sentinel_community permit {{ constants.bgp.sentinel_community }}
+!
+route-map FROM_BGP_SENTINEL permit 100
+ match community sentinel_community
+{% endif %}
+!
+route-map FROM_BGP_SENTINEL deny 200
+!
+route-map TO_BGP_SENTINEL permit 100
+!
+! end of template: bgpd/templates/sentinels/policies.conf.j2
+!

--- a/sonic-vpp-setup.sh
+++ b/sonic-vpp-setup.sh
@@ -25,10 +25,12 @@ VPPLIBPATH=$PWD/platform/saivpp/vpplib
 cd ./build/sonic-buildimage
 
 # Below is the build label information
+
+#327510	20230731.7	master	Azure.sonic-buildimage.official.vs	succeeded	2023-07-31T08:36:27	2023-07-31T13:56:49	141132c94b
+WORKING_LABEL=141132c94b
+
 SONIC_CHECKOUT_LABEL=${SONIC_CHECKOUT_LABEL:=$WORKING_LABEL}
 
-#323306	20230725.7	master	Azure.sonic-buildimage.official.vs	succeeded	2023-07-25T08:24:26	2023-07-25T14:01:29	dc139cfc32
-WORKING_LABEL=dc139cfc32
 git checkout $SONIC_CHECKOUT_LABEL
 
 make init

--- a/start_sonic_vpp.sh
+++ b/start_sonic_vpp.sh
@@ -192,7 +192,7 @@ NETPORTS_PATH="/run/sonic-vpp/$SONIC_VPP-netports_bus"
 DPDK_DISABLE="y"
 
 UIO_DRV=${UIO_DRV:=vfio-pci}
-NO_LINUX_NL=${NO_LINUX_NL:="n"}
+NO_LINUX_NL=${NO_LINUX_NL:="y"}
 
 if [ "$CMD" == "start" ]; then
     if [ "$NETPORTS" == "" ]; then


### PR DESCRIPTION
Added bgp sentinel changes to container image.
Enable address/interface/routes configuration using VPP API. Disable linux_nl.