### PR TITLE
Issue 107: SONIC_VPP_SWITH breaks traffic

### DIFF
--- a/platform/saivpp/vpplib/SwitchStateBase.h
+++ b/platform/saivpp/vpplib/SwitchStateBase.h
@@ -1073,7 +1073,6 @@ namespace saivpp
 	       _Out_ std::string& ifname);
 
         protected:
-            bool is_sonic_vpp_switch ();
 	    void populate_if_mapping();
 	    const char *tap_to_hwif_name(const char *name);
             const char *hwif_to_tap_name(const char *name);
@@ -1085,8 +1084,6 @@ namespace saivpp
 	    std::map<std::string, std::string> m_hostif_hwif_map;
 	    std::map<std::string, std::string> m_hwif_hostif_map;
 	    int mapping_init = 0;
-            bool vpp_switch_env_read = false;
-            bool sonic_vpp_switch = false;
             bool m_run_vpp_events_thread = true;
             bool VppEventsThreadStarted = false;
 	    std::shared_ptr<std::thread> m_vpp_thread;

--- a/platform/saivpp/vpplib/SwitchStateBaseHostif.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseHostif.cpp
@@ -728,20 +728,20 @@ sai_status_t SwitchStateBase::vpp_create_hostif_tap_interface(
 
     sai_attribute_t attr;
 
-	memset(&attr, 0, sizeof(attr));
+    memset(&attr, 0, sizeof(attr));
 
-	attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+    attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
 
-	sai_status_t status = get(SAI_OBJECT_TYPE_SWITCH, m_switch_id, 1, &attr);
+    sai_status_t status = get(SAI_OBJECT_TYPE_SWITCH, m_switch_id, 1, &attr);
 
-	if (status != SAI_STATUS_SUCCESS)
-        {
-	    SWSS_LOG_ERROR("failed to get SAI_SWITCH_ATTR_SRC_MAC_ADDRESS on switch %s: %s",
-			   sai_serialize_object_id(m_switch_id).c_str(),
-			   sai_serialize_status(status).c_str());
-	}
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("failed to get SAI_SWITCH_ATTR_SRC_MAC_ADDRESS on switch %s: %s",
+                       sai_serialize_object_id(m_switch_id).c_str(),
+                       sai_serialize_status(status).c_str());
+    }
 
-	int err = vpp_set_dev_mac_address(name.c_str(), attr.value.mac);
+    int err = vpp_set_dev_mac_address(name.c_str(), attr.value.mac);
 
     if (err < 0)
     {

--- a/platform/saivpp/vpplib/SwitchStateBaseHostif.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseHostif.cpp
@@ -610,21 +610,6 @@ bool SwitchStateBase::hostif_create_tap_veth_forwarding(
     return true;
 }
 
-bool SwitchStateBase::is_sonic_vpp_switch ()
-{
-    if (vpp_switch_env_read == false)
-    {
-	const char *val;
-
-	val = getenv("SONIC_VPP_SWITCH");
-	if (val && (*val == 'y' || *val == 'Y')) {
-	    sonic_vpp_switch = true;
-	}
-	vpp_switch_env_read = true;
-    }
-    return sonic_vpp_switch;
-}
-
 sai_status_t SwitchStateBase::vpp_create_hostif_tap_interface(
         _In_ uint32_t attr_count,
         _In_ const sai_attribute_t *attr_list)
@@ -740,8 +725,8 @@ sai_status_t SwitchStateBase::vpp_create_hostif_tap_interface(
 	SWSS_LOG_NOTICE("VPP interface %s(%s) oper state %s", hwif_name, dev,
 			(link_up ? "UP" : "DOWN"));
     }
-    if (is_sonic_vpp_switch()) {
-        sai_attribute_t attr;
+
+    sai_attribute_t attr;
 
 	memset(&attr, 0, sizeof(attr));
 
@@ -758,64 +743,28 @@ sai_status_t SwitchStateBase::vpp_create_hostif_tap_interface(
 
 	int err = vpp_set_dev_mac_address(name.c_str(), attr.value.mac);
 
-	if (err < 0)
-        {
-	    SWSS_LOG_ERROR("failed to set MAC address %s for %s",
-			   sai_serialize_mac(attr.value.mac).c_str(),
-			   name.c_str());
-	    close(tapfd);
-
-	    return SAI_STATUS_FAILURE;
-	}
-    }
-
-    /*
-    std::string vname = vpp_get_veth_name(name, obj_id);
-
-    int mtu = ETH_FRAME_BUFFER_SIZE;
-
-    sai_attribute_t attrmtu;
-
-    attrmtu.id = SAI_PORT_ATTR_MTU;
-
-    if (get(SAI_OBJECT_TYPE_PORT, obj_id, 1, &attrmtu) == SAI_STATUS_SUCCESS)
+    if (err < 0)
     {
-        mtu = attrmtu.value.u32;
-
-        SWSS_LOG_INFO("setting new MTU: %d on %s", mtu, vname.c_str());
-    }
-
-    vpp_set_dev_mtu(vname.c_str(), mtu);
-
-    attr.id = SAI_PORT_ATTR_ADMIN_STATE;
-
-    status = get(SAI_OBJECT_TYPE_PORT, obj_id, 1, &attr);
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("failed to get admin state for port %s",
-                sai_serialize_object_id(obj_id).c_str());
-
-        return status;
-    }
-
-    if (ifup(vname.c_str(), obj_id, attr.value.booldata, false))
-    {
-        SWSS_LOG_ERROR("ifup failed on %s", vname.c_str());
+        SWSS_LOG_ERROR("failed to set MAC address %s for %s",
+            sai_serialize_mac(attr.value.mac).c_str(),
+            name.c_str());
+        close(tapfd);
 
         return SAI_STATUS_FAILURE;
     }
 
-    if (!hostif_create_tap_veth_forwarding(name, tapfd, obj_id))
+    err = sw_interface_set_mac(hwif_name, attr.value.mac);
+    if (err < 0)
     {
-        SWSS_LOG_ERROR("forwarding rule on %s was not added", name.c_str());
+        SWSS_LOG_ERROR("failed to set MAC address %s for %s",
+            sai_serialize_mac(attr.value.mac).c_str(),
+            hwif_name);
+        close(tapfd);
+
+        return SAI_STATUS_FAILURE;
     }
+    SWSS_LOG_INFO("Successfully set mac to %s for %s", sai_serialize_mac(attr.value.mac).c_str(), name.c_str());
 
-    SWSS_LOG_INFO("mapping interface %s to port id %s",
-            vname.c_str(),
-            sai_serialize_object_id(obj_id).c_str());
-
-    */
     setIfNameToPortId(name, obj_id);
     setPortIdToTapName(obj_id, name);
 

--- a/platform/saivpp/vpplib/vppxlate/SaiVppXlate.h
+++ b/platform/saivpp/vpplib/vppxlate/SaiVppXlate.h
@@ -186,7 +186,7 @@ typedef enum {
     extern int interface_set_state (const char *hwif_name, bool is_up);
     extern int hw_interface_set_mtu(const char *hwif_name, uint32_t mtu);
     extern int sw_interface_set_mtu(const char *hwif_name, uint32_t mtu, int type);
-
+    extern int sw_interface_set_mac(const char *hwif_name, uint8_t *mac_address);
     extern int ip_vrf_add(uint32_t vrf_id, const char *vrf_name, bool is_ipv6);
     extern int ip_vrf_del(uint32_t vrf_id, const char *vrf_name, bool is_ipv6);
 

--- a/sonic-vpp-setup.sh
+++ b/sonic-vpp-setup.sh
@@ -67,7 +67,6 @@ git apply $MKRULES_PATH/files/build_templates/sonic_debian_extension.j2.patch
 cp $MKRULES_PATH/files/sai.profile ./src/sonic-device-data/src/sai.vs_profile
 
 # Copy the sonic-vpp configuration scripts
-cp $MKRULES_PATH/files/scripts/sonic_vpp_cfg.sh ./files/scripts/sonic_vpp_cfg.sh
 cp $MKRULES_PATH/files/scripts/vpp_ports_setup.sh ./files/scripts/vpp_ports_setup.sh
 
 # Setup the swss docker file template to ignore the vpp sysctl during installation


### PR DESCRIPTION
### Problem
SONIC_VPP_SWITH is introduced to set interface MAC to switch MAC address passed in via SAI_SWITCH_ATTR_SRC_MAC_ADDRESS. However, when this is set when invoking sonic_cpp_cfg.sh, ping between 2 back to back sonic-vpp VM stops working. This is because SwitchStateBase::vpp_create_hostif_tap_interface only changes the Mac address in the kernel but not in vpp. When packets coming in with SAI_SWITCH_ATTR_SRC_MAC_ADDRESS as DMAC, it is dropped by vpp in MyMAC check.
### What this change is doing

- Set mac address for interfaces in vpp
- Remove SONIC_VPP_SWITCH since sonic requires inteface mac to be SAI_SWITCH_ATTR_SRC_MAC_ADDRESS
- Fixed a bug introduced in PR 106: sonic_vpp_cfg.sh has been deleted but sonic-vpp-setup.sh not cleaned up properly