### PR TITLE
Issue 109: VxLAN VNET doesn't support ECMP nexthop group

### DIFF
--- a/platform/saivpp/vpplib/SaiObjectDB.cpp
+++ b/platform/saivpp/vpplib/SaiObjectDB.cpp
@@ -305,7 +305,7 @@ SaiCachedObject::get_attr(sai_attribute_t &attr) const
 }
 
 sai_status_t 
-SaiCachedObject::get_manditory_attr(sai_attribute_t &attr) const 
+SaiCachedObject::get_mandatory_attr(sai_attribute_t &attr) const 
 {
     for (uint32_t ii = 0; ii < m_attr_count; ii++) {
         if (m_attr_list[ii].id == attr.id) {
@@ -324,7 +324,7 @@ SaiDBObject::get_attr(sai_attribute_t &attr) const
 }
 
 sai_status_t
-SaiDBObject::get_manditory_attr(sai_attribute_t &attr) const 
+SaiDBObject::get_mandatory_attr(sai_attribute_t &attr) const 
 {
     /* we could make a copy of all the attributes and cache in this object*/
     auto status = m_switch_db->get(m_type, m_id, 1, &attr);

--- a/platform/saivpp/vpplib/SaiObjectDB.h
+++ b/platform/saivpp/vpplib/SaiObjectDB.h
@@ -30,7 +30,8 @@ namespace saivpp
       move SaiObjectDB to SwitchState. When we need to read an object, such as get_linked_object, get it from m_objectHash in SwitchState
     */
     class SwitchStateBase;
-
+    class SaiDBObject;
+    
     /*
       SaiObject is the base class for all objects in the SaiObjectDB.
       It represents a generic SAI object with a type, serialized ID, and associated attributes.
@@ -44,17 +45,25 @@ namespace saivpp
 
         virtual sai_status_t get_attr(_Out_ sai_attribute_t &attr) const = 0;
 
+        // Get the manditory attribute of the object. If not found, log an error and return SAI_STATUS_FAILURE
+        virtual sai_status_t get_manditory_attr(_Out_ sai_attribute_t &attr) const = 0;
+
         const std::string& get_id() const { return m_id; }
 
         sai_object_type_t get_type() const { return m_type; }
 
-        std::shared_ptr<SaiObject> get_linked_object(_In_ sai_object_type_t linked_object_type, _In_ sai_attr_id_t link_attr_id) const;
-        std::vector<std::shared_ptr<SaiObject>> get_linked_objects(_In_ sai_object_type_t linked_object_type, _In_ sai_attr_id_t link_attr_id) const;
+        std::shared_ptr<SaiDBObject> get_linked_object(_In_ sai_object_type_t linked_object_type, _In_ sai_attr_id_t link_attr_id) const;
+
+        std::vector<std::shared_ptr<SaiDBObject>> get_linked_objects(_In_ sai_object_type_t linked_object_type, _In_ sai_attr_id_t link_attr_id) const;
+
+        // Get the attribute name from the attribute ID
+        const char* get_attr_name(_In_ sai_attr_id_t attr_id) const;
     protected:
         SwitchStateBase* m_switch_db;
         sai_object_type_t m_type;    
         std::string m_id;
     };
+    
     /**
      * @brief The SaiCachedObject class represents a SAI object that has not been created in the SaiObjectDB. This is typically
      * used for objects that are being created through the SAI API.
@@ -87,6 +96,15 @@ namespace saivpp
          * @return sai_status_t The status of the attribute retrieval operation.
          */
         sai_status_t get_attr(_Out_ sai_attribute_t &attr) const override;
+
+        /**
+         * @brief Retrieves the value of a specific attribute of the SAI object. If the attribute is not found, log an error and 
+         *        return SAI_STATUS_FAILURE.
+         * 
+         * @param attr [out] A reference to the sai_attribute_t structure to store the attribute value.
+         * @return sai_status_t The status of the attribute retrieval operation.
+         */
+        sai_status_t get_manditory_attr(_Out_ sai_attribute_t &attr) const override;
 
     private:
         /**< The number of attributes associated with the SAI object. */
@@ -126,6 +144,15 @@ namespace saivpp
          * @return The status of the operation.
          */
         sai_status_t get_attr(_Out_ sai_attribute_t &attr) const override;
+        
+        /**
+         * @brief Retrieves the value of a specific attribute of the SAI object. If the attribute is not found, log an error and 
+         *        return SAI_STATUS_FAILURE.
+         * 
+         * @param attr [out] A reference to the sai_attribute_t structure to store the attribute value.
+         * @return sai_status_t The status of the attribute retrieval operation.
+         */
+        sai_status_t get_manditory_attr(_Out_ sai_attribute_t &attr) const override;
 
         /**
          * @brief Retrieves the child objects of the specified type.
@@ -240,7 +267,7 @@ namespace saivpp
          * @param id The ID of the SAI object.
          * @return A shared pointer to the SAI object, or nullptr if the object is not found.
          */
-        std::shared_ptr<SaiObject> get(
+        std::shared_ptr<SaiDBObject> get(
                     _In_ sai_object_type_t object_type,
                     _In_ const std::string& id);
 

--- a/platform/saivpp/vpplib/SaiObjectDB.h
+++ b/platform/saivpp/vpplib/SaiObjectDB.h
@@ -46,7 +46,7 @@ namespace saivpp
         virtual sai_status_t get_attr(_Out_ sai_attribute_t &attr) const = 0;
 
         // Get the manditory attribute of the object. If not found, log an error and return SAI_STATUS_FAILURE
-        virtual sai_status_t get_manditory_attr(_Out_ sai_attribute_t &attr) const = 0;
+        virtual sai_status_t get_mandatory_attr(_Out_ sai_attribute_t &attr) const = 0;
 
         const std::string& get_id() const { return m_id; }
 
@@ -104,7 +104,7 @@ namespace saivpp
          * @param attr [out] A reference to the sai_attribute_t structure to store the attribute value.
          * @return sai_status_t The status of the attribute retrieval operation.
          */
-        sai_status_t get_manditory_attr(_Out_ sai_attribute_t &attr) const override;
+        sai_status_t get_mandatory_attr(_Out_ sai_attribute_t &attr) const override;
 
     private:
         /**< The number of attributes associated with the SAI object. */
@@ -152,7 +152,7 @@ namespace saivpp
          * @param attr [out] A reference to the sai_attribute_t structure to store the attribute value.
          * @return sai_status_t The status of the attribute retrieval operation.
          */
-        sai_status_t get_manditory_attr(_Out_ sai_attribute_t &attr) const override;
+        sai_status_t get_mandatory_attr(_Out_ sai_attribute_t &attr) const override;
 
         /**
          * @brief Retrieves the child objects of the specified type.

--- a/platform/saivpp/vpplib/SwitchStateBase.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBase.cpp
@@ -196,11 +196,6 @@ sai_status_t SwitchStateBase::create(
     {       
         return createNexthop(serializedObjectId, switch_id, attr_count, attr_list);
     }
-    
-    if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER)
-    {
-        return NexthopGrpMemberAdd(serializedObjectId, switch_id, attr_count, attr_list);
-    }
 
     if (object_type == SAI_OBJECT_TYPE_NEIGHBOR_ENTRY)
     {
@@ -483,16 +478,6 @@ sai_status_t SwitchStateBase::remove(
     if (object_type == SAI_OBJECT_TYPE_ROUTE_ENTRY)
     {
         return removeIpRoute(serializedObjectId);
-    }
-
-    if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER)
-    {
-        return NexthopGrpMemberRemove(serializedObjectId);
-    }
-
-    if (object_type == SAI_OBJECT_TYPE_NEXT_HOP_GROUP)
-    {
-        return NexthopGrpRemove(serializedObjectId);
     }
     
     if (object_type == SAI_OBJECT_TYPE_NEXT_HOP)
@@ -854,11 +839,7 @@ sai_status_t SwitchStateBase::get(
 
         if (ait == attrHash.end())
         {
-            SWSS_LOG_WARN("%s not implemented on %s",
-                    meta->attridname,
-                    serializedObjectId.c_str());
-
-            return SAI_STATUS_NOT_IMPLEMENTED;
+            return SAI_STATUS_ITEM_NOT_FOUND;
         }
 
         auto attr = ait->second->getAttr();
@@ -1125,7 +1106,7 @@ sai_status_t SwitchStateBase::bulkSet(
     return status;
 }
 
-std::shared_ptr<SaiObject> 
+std::shared_ptr<SaiDBObject> 
 SwitchStateBase::get_sai_object(
                 _In_ sai_object_type_t object_type,
                 _In_ const std::string &serializedObjectId)

--- a/platform/saivpp/vpplib/SwitchStateBase.h
+++ b/platform/saivpp/vpplib/SwitchStateBase.h
@@ -52,7 +52,9 @@
         snprintf(buffer, 512, msg, ##__VA_ARGS__); \
         SWSS_LOG_ERROR("%s: status %d", buffer, status); \
         return _status; } }
-
+#define CHECK_STATUS_QUIET(status) {                                  \
+    sai_status_t _status = (status);                            \
+    if (_status != SAI_STATUS_SUCCESS) { return _status; } }
 typedef struct vpp_ace_cntr_info_ {
     sai_object_id_t tbl_oid;
     sai_object_id_t ace_oid;
@@ -390,7 +392,7 @@ namespace saivpp
                               _In_ sai_attr_id_t attr_id,
                              _Inout_ sai_s32_list_t *enum_values_capability);
 
-            std::shared_ptr<SaiObject> get_sai_object(
+            std::shared_ptr<SaiDBObject> get_sai_object(
                     _In_ sai_object_type_t object_type,
                     _In_ const std::string &serialized_object_id);
         protected:
@@ -782,21 +784,12 @@ namespace saivpp
 	    std::unordered_map<std::string, std::string> lpbIpToHostIfMap;
 	    std::unordered_map<std::string, std::string> lpbIpToIfMap;
             std::unordered_map<std::string, std::string> lpbHostIfToVppIfMap;
-
-            std::map<sai_object_id_t, std::list<sai_object_id_t>> m_nxthop_grp_mbr_map;
-
         protected:
-            sai_status_t NexthopGrpRemove(
-                _In_ const std::string &serializedObjectId);
-
-            sai_status_t NexthopGrpMemberRemove(
-                _In_ const std::string &serializedObjectId);
-
-            sai_status_t NexthopGrpMemberAdd(
-                _In_ const std::string &serializedObjectId,
-                _In_ sai_object_id_t switch_id,
-                _In_ uint32_t attr_count,
-                _In_ const sai_attribute_t *attr_list);
+            sai_status_t fillNHGrpMember(
+                nexthop_grp_member_t *nxt_grp_member, 
+                sai_object_id_t next_hop_oid, 
+                uint32_t next_hop_weight, 
+                uint32_t next_hop_sequence);
 
             sai_status_t IpRouteNexthopGroupEntry(
                 _In_ sai_object_id_t next_hop_grp_oid,

--- a/platform/saivpp/vpplib/SwitchStateBaseNexthop.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseNexthop.cpp
@@ -51,7 +51,7 @@ sai_status_t SwitchStateBase::IpRouteNexthopGroupEntry(
         return SAI_STATUS_FAILURE;        
     }
     
-    CHECK_STATUS_QUIET(nhg_obj->get_manditory_attr(attr));
+    CHECK_STATUS_QUIET(nhg_obj->get_mandatory_attr(attr));
     if (attr.value.s32 != SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP &&
         attr.value.s32 != SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_ORDERED_ECMP) {
         SWSS_LOG_ERROR("Unsupported type (%d) in nexthop group %s", attr.value.s32, nhg_soid.c_str());
@@ -75,7 +75,7 @@ sai_status_t SwitchStateBase::IpRouteNexthopGroupEntry(
         nexthop_grp_member_t mbr;
         
         attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID;
-        CHECK_STATUS_QUIET(member_obj->get_manditory_attr(attr));
+        CHECK_STATUS_QUIET(member_obj->get_mandatory_attr(attr));
         next_hop_oid = attr.value.oid;
 
         attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_WEIGHT;
@@ -87,7 +87,7 @@ sai_status_t SwitchStateBase::IpRouteNexthopGroupEntry(
 
         if (group_type == SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_ORDERED_ECMP) {
             attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_SEQUENCE_ID;
-            CHECK_STATUS_QUIET(member_obj->get_manditory_attr(attr));
+            CHECK_STATUS_QUIET(member_obj->get_mandatory_attr(attr));
             next_hop_sequence = attr.value.u32;
         }
         else {
@@ -186,7 +186,7 @@ SwitchStateBase::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_objec
     }
     
     attr.id = SAI_NEXT_HOP_ATTR_TYPE;
-    CHECK_STATUS_QUIET(nh_obj->get_manditory_attr(attr));
+    CHECK_STATUS_QUIET(nh_obj->get_mandatory_attr(attr));
     int32_t next_hop_type = attr.value.s32;
     if (next_hop_type != SAI_NEXT_HOP_TYPE_IP && next_hop_type != SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP) {
         return SAI_STATUS_NOT_IMPLEMENTED;
@@ -194,7 +194,7 @@ SwitchStateBase::fillNHGrpMember(nexthop_grp_member_t *nxt_grp_member, sai_objec
 
     attr.id = SAI_NEXT_HOP_ATTR_IP;
     sai_ip_address_t ip_address;
-    CHECK_STATUS_QUIET(nh_obj->get_manditory_attr(attr));
+    CHECK_STATUS_QUIET(nh_obj->get_mandatory_attr(attr));
     ip_address = attr.value.ipaddr;
 
     nxt_grp_member->addr = ip_address;

--- a/platform/saivpp/vpplib/SwitchStateBaseRoute.cpp
+++ b/platform/saivpp/vpplib/SwitchStateBaseRoute.cpp
@@ -100,7 +100,7 @@ void create_vpp_nexthop_entry (
     vpp_nexthop->hwif_name = hwif_name;
     vpp_nexthop->sw_if_index = nxt_grp_member->sw_if_index;
     vpp_nexthop->weight = (uint8_t) nxt_grp_member->weight;
-    vpp_nexthop->preference = (uint8_t) nxt_grp_member->seq_id;
+    vpp_nexthop->preference = 0;
 }
 
 sai_status_t SwitchStateBase::IpRouteAddRemove(

--- a/platform/saivpp/vpplib/TunnelManager.cpp
+++ b/platform/saivpp/vpplib/TunnelManager.cpp
@@ -135,13 +135,8 @@ TunnelManager::tunnel_encap_nexthop_action(
         if (attr.value.s32 != SAI_TUNNEL_MAP_TYPE_VIRTUAL_ROUTER_ID_TO_VNI) {
             continue;
         }
-        auto mapper_table = std::dynamic_pointer_cast<SaiDBObject>(tunnel_encap_mapper);
-        if (!mapper_table) {
-            SWSS_LOG_ERROR("Failed to cast tunnel_encap_mapper to SaiDBObject. OID %s", 
-                tunnel_encap_mapper->get_id().c_str());
-            return SAI_STATUS_FAILURE;
-        }
-        auto tunnel_encap_mapper_entries = mapper_table->get_child_objs(SAI_OBJECT_TYPE_TUNNEL_MAP_ENTRY);
+
+        auto tunnel_encap_mapper_entries = tunnel_encap_mapper->get_child_objs(SAI_OBJECT_TYPE_TUNNEL_MAP_ENTRY);
         if (tunnel_encap_mapper_entries == nullptr) {
             SWSS_LOG_DEBUG("Empty tunnel_encap_mapper table. OID %s", 
                 tunnel_encap_mapper->get_id().c_str());


### PR DESCRIPTION
### Problem
VxLAN VNET route doesn't support ECMP nexthop group. This failed sonic-mgmt test vxlan/test_vxlan_ecmp.py::Test_VxLAN_ecmp_create::test_vxlan_configure_route1_ecmp_group_a and others

### What this change is doing

- Support TUNNEL_ENCAP nexthop type in Nexthop Group.
- Add get_mandatory_attr to SaiObject to simplify error handling
- Use SaiObjectDB to automatically manage the relationship between NEXT_HOP_MEMBER and NEXT_HOP_GROUP