### PR TITLE
Fix BFD to work with latest VPP code

### DIFF
--- a/platform/vpp/vppbld/Makefile
+++ b/platform/vpp/vppbld/Makefile
@@ -15,10 +15,9 @@
 SHELL = /bin/bash
 .SHELLFLAGS += -e
 
-VPP_URL = https://github.com/abdbaig/vpp.git
-VPP_BRANCH = 21_days_old
+VPP_URL = https://gerrit.fd.io/r/vpp
 VPP_SHA =
-VPP_LAG = 21
+VPP_LAG = 10
 USER = $(shell id -un)
 UID = $(shell id -u)
 GUID = $(shell id -g)
@@ -69,7 +68,7 @@ build_vpp:
 .PHONY: repo_clone
 repo_clone:
 	rm -rf $(VPP_REPO_DIR)
-	git clone -b $(VPP_BRANCH) $(VPP_URL) $(VPP_REPO_DIR)
+        git clone $(VPP_URL) $(VPP_REPO_DIR)
 	cp -r $(VPP_CUSTOM_PLUGINS_DIR)/* $(VPP_REPO_DIR)/src/plugins/
 	pushd $(VPP_REPO_DIR)
 	@VPP_SHA=`git log --until "$(VPP_LAG) days ago" -1 --format="%h"`


### PR DESCRIPTION
Previous Sonic VPP BFD code was written for VPP multihop BFD code changes that weren't approved yet. Now that approved changes have been pushed in into VPP, there are some differences in how the APIs should called. There is no V2 version of the API - it uses the existing APIs now. Also a new function called vpp_bfd_udp_enable_multihop() must be called during VPP init to enable multihop BFD support. This is so sw_if_index value of 0xFFFFFFFF in BFD APIs can be taken as a multihop indicator. If multihop_enable API is not called then VPP works in single-hop BFD mode all the time, meaning it takes 0xFFFFFFFF as an interface ID. Even with multihop enabled, single-hop BFD sessions can be set up as long as sw_if_index is not 0xFFFFFFFF.