### PR TITLE
Issue #138: Fix instability in test_vxlan_ecmp sonic-mgmt test

### DIFF
--- a/saivpp/src/TunnelManager.cpp
+++ b/saivpp/src/TunnelManager.cpp
@@ -320,6 +320,7 @@ TunnelManager::create_vpp_vxlan_decap(
     vpp_status = create_bvi_interface(bvi_mac, bd_id);
     if (vpp_status != 0) {
         SWSS_LOG_ERROR("Failed to create bvi interface");
+        m_switch_db->dynamic_bd_id_pool.free(bd_id);
         return SAI_STATUS_FAILURE;
     }
     // Get new list of physical interfaces from VPP
@@ -390,6 +391,7 @@ TunnelManager::remove_vpp_vxlan_decap(
 
     delete_bvi_interface(hw_bvi_ifname);
 
+    m_switch_db->dynamic_bd_id_pool.free(tunnel_data.bd_id);
     refresh_interfaces_list();
     //bd is create automatically when the fist interface is add to it but requires manual deletion
     vpp_bridge_domain_add_del(tunnel_data.bd_id, false);

--- a/saivpp/src/vppxlate/SaiVppXlate.c
+++ b/saivpp/src/vppxlate/SaiVppXlate.c
@@ -886,8 +886,6 @@ vl_api_bfd_udp_session_event_t_handler (vl_api_bfd_udp_session_event_t *msg)
        vpp_ev_enqueue(evinfo);
     }
 
-    set_reply_status(0);
-
     SAIVPP_DEBUG("BFD udp session event, multihop: %d, sw_if_index: %d, "
                  "state: %d ",
                  multihop, htonl(msg->sw_if_index), htonl(msg->state));


### PR DESCRIPTION
### why

Addressing issue #138:
test_vxlan_ecmp sonic-mgmt test failed occasionally. This is because vl_api_bfd_udp_session_event_t_handler calls set_reply_status. The callback is for unsolicited event (bfd state update). set_reply_status should not be called for unsolicited event and it can mess up other requests. In our case, it is vxlan tunnel create request.

In the long run, we should make request/response more robust by setting request_message_id in the context of request to match its response.

### What this PR does
remove set_reply_status from vl_api_bfd_udp_session_event_t_handler
Also fixed bridge domain ID resource leak. BD ID is not put back to the resource pool when vxlan decap is deleted.