### PR TITLE
add support for Marvell mlx5 NICs

### DIFF
--- a/sonic-platform-modules-vpp/files/usr/bin/vpp_ports_setup.sh
+++ b/sonic-platform-modules-vpp/files/usr/bin/vpp_ports_setup.sh
@@ -36,11 +36,11 @@ function bind_ports_to_uio()
 	    continue
 	fi
 	CUR_DRIVER=$(lspci -k -s $PCI_ID | grep "Kernel driver in use:" | cut -d ':' -f2 | xargs)
-  # Only skip mlx5_core devices as they need their native driver
-  if [ "$CUR_DRIVER" == "mlx5_core" ]; then
-      echo "Skipping device with mlx5_core driver: $pci_dev"
-      continue
-  fi
+	# Only skip mlx5_core devices as they need their native driver
+	if [ "$CUR_DRIVER" == "mlx5_core" ]; then
+			echo "Skipping device with mlx5_core driver: $pci_dev"
+			continue
+	fi
 
 	if [ "$CUR_DRIVER" != "" ] && [ "$CUR_DRIVER" != "$UIO_DRV" ]; then
 	    echo "Un-binding port $port($PCI_ID) from driver $CUR_DRIVER"

--- a/sonic-platform-modules-vpp/files/usr/bin/vpp_ports_setup.sh
+++ b/sonic-platform-modules-vpp/files/usr/bin/vpp_ports_setup.sh
@@ -36,6 +36,12 @@ function bind_ports_to_uio()
 	    continue
 	fi
 	CUR_DRIVER=$(lspci -k -s $PCI_ID | grep "Kernel driver in use:" | cut -d ':' -f2 | xargs)
+  # Only skip mlx5_core devices as they need their native driver
+  if [ "$CUR_DRIVER" == "mlx5_core" ]; then
+      echo "Skipping device with mlx5_core driver: $pci_dev"
+      continue
+  fi
+
 	if [ "$CUR_DRIVER" != "" ] && [ "$CUR_DRIVER" != "$UIO_DRV" ]; then
 	    echo "Un-binding port $port($PCI_ID) from driver $CUR_DRIVER"
 	    echo "$PCI_ID" > /sys/bus/pci/drivers/$CUR_DRIVER/unbind


### PR DESCRIPTION
vpp_ports_setup: skip MLX5 devices with native drivers

**Problem:**
The vpp_ports_setup.sh script currently attempts to bind all NICs
to uio_pci_generic driver. However, newer Mellanox/Marvell NICs
(using mlx5_core) perform better with their native driver.

**Solution:**
Modified vpp_ports_setup.sh to skip devices using mlx5_core driver.
This allows Marvell NICs to keep their native driver while other NICs 
continue to be bound to uio_pci_generic.

**Changes:**
- Added check to skip devices with mlx5_core driver

**Testing:**
Tested with:
- Mellanox ConnectX-4/5/6 cards (mlx5_core)

admin@sonic:~$ docker exec -it syncd bash
root@sonic:/# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 06:53 pts/0    00:00:00 /usr/bin/python3 /usr/local/bin/supervisord
root           8       1  0 06:53 pts/0    00:00:00 python3 /usr/bin/supervisor-proc-exit-listener --container-name syncd
root           9       1  0 06:53 pts/0    00:00:00 /bin/bash /usr/local/bin/vpp_init.sh
root          18       9 99 06:53 pts/0    00:05:43 /usr/bin/vpp -c /tmp/vppnwXGgu.conf
root          24       1  0 06:53 pts/0    00:00:00 /usr/sbin/rsyslogd -n -iNONE
root          31       1  1 06:53 pts/0    00:00:02 /usr/bin/syncd -u -s -B null -p /usr/share/sonic/hwsku/sai.profile
root         246       0  0 06:56 pts/1    00:00:00 bash
root         252     246  0 06:56 pts/1    00:00:00 ps -ef
root@sonic:/# vppctl
    _______    _        _   _____  ___
 __/ __/ _ \  (_)__    | | / / _ \/ _ \
 _/ _// // / / / _ \   | |/ / ___/ ___/
 /_/ /____(_)_/\___/   |___/_/  /_/

vpp# show pci
Address      Sock VID:PID     Link Speed    Driver          Product Name                    Vital Product Data
0000:00:03.0   0  1af4:1000   unknown       virtio-pci
0000:00:07.0   0  15b3:1017   unknown       mlx5_core       CX516A - ConnectX-5 QSFP28       PN: MCX516A-CCAT
                                                                                            EC: AC
                                                                                            V2: 0x 4d 43 58 35 31 36 41 2d ...
                                                                                            SN: MT2030J21587
                                                                                            V3: 0x 32 36 64 62 36 38 64 63 ...
                                                                                            VA: 0x 4d 4c 58 3a 4d 4f 44 4c ...
                                                                                            V0: 0x 50 43 49 65 47 65 6e 33 ...
                                                                                            RV: 0x d6 00 00
0000:00:08.0   0  15b3:1017   unknown       mlx5_core       CX516A - ConnectX-5 QSFP28       PN: MCX516A-CCAT
                                                                                            EC: AC
                                                                                            V2: 0x 4d 43 58 35 31 36 41 2d ...
                                                                                            SN: MT2030J21587
                                                                                            V3: 0x 32 36 64 62 36 38 64 63 ...
                                                                                            VA: 0x 4d 4c 58 3a 4d 4f 44 4c ...
                                                                                            V0: 0x 50 43 49 65 47 65 6e 33 ...
                                                                                            RV: 0x d6 00 00
vpp# exit
root@sonic:/# exit
exit
admin@sonic:~$ lscpi
-bash: lscpi: command not found
admin@sonic:~$ sudo lspci
00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma] (rev 02)
00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
00:01.1 IDE interface: Intel Corporation 82371SB PIIX3 IDE [Natoma/Triton II]
00:01.3 Bridge: Intel Corporation 82371AB/EB/MB PIIX4 ACPI (rev 03)
00:02.0 VGA compatible controller: Cirrus Logic GD 5446
00:03.0 Ethernet controller: Red Hat, Inc. Virtio network device
00:04.0 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #1 (rev 03)
00:04.1 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #2 (rev 03)
00:04.2 USB controller: Intel Corporation 82801I (ICH9 Family) USB UHCI Controller #3 (rev 03)
00:04.7 USB controller: Intel Corporation 82801I (ICH9 Family) USB2 EHCI Controller #1 (rev 03)
00:05.0 SATA controller: Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode] (rev 02)
00:06.0 Unclassified device [00ff]: Red Hat, Inc. Virtio memory balloon
00:07.0 Ethernet controller: Mellanox Technologies MT27800 Family [ConnectX-5]
00:08.0 Ethernet controller: Mellanox Technologies MT27800 Family [ConnectX-5]
admin@sonic:~$ lspci -k -s  00:06.0
00:06.0 Unclassified device [00ff]: Red Hat, Inc. Virtio memory balloon
        Subsystem: Red Hat, Inc. Virtio memory balloon
        Kernel driver in use: virtio-pci
        Kernel modules: virtio_pci
admin@sonic:~$ lspci -k -s  00:07.0
00:07.0 Ethernet controller: Mellanox Technologies MT27800 Family [ConnectX-5]
        Subsystem: Mellanox Technologies Mellanox ConnectX-5 MCX516A-CCAT
        Kernel driver in use: mlx5_core
        Kernel modules: mlx5_core
