### PR TITLE
Increase cpu cores in vpp

### DIFF
--- a/docker-syncd-vpp/conf/startup.conf.tmpl
+++ b/docker-syncd-vpp/conf/startup.conf.tmpl
@@ -87,12 +87,12 @@ cpu {
 	## Skipped CPU core(s) are not used for pinning main thread and working thread(s).
 	## The main thread is automatically pinned to the first available CPU core and worker(s)
 	## are pinned to next free CPU core(s) after core assigned to main thread
-	# skip-cores 4
+	skip-cores 1
 
 	## Specify a number of workers to be created
 	## Workers are pinned to N consecutive CPU cores while skipping "skip-cores" CPU core(s)
 	## and main thread's CPU core
-	# workers 2
+	workers 2
 
 	## Set scheduling policy and priority of main and worker threads
 

--- a/saivpp/src/vppxlate/SaiAclStats.c
+++ b/saivpp/src/vppxlate/SaiAclStats.c
@@ -28,8 +28,8 @@ static void handle_stat_two (const char *stat_name, uint32_t ace_index,
     vpp_ace_stats_t *st_p = (vpp_ace_stats_t *) data;
 
     if (st_p->ace_index == ace_index) {
-	st_p->packets = count1;
-	st_p->bytes = count2;
+        st_p->packets += count1;
+        st_p->bytes += count2;
     }
 }
 

--- a/saivpp/src/vppxlate/SaiIntfStats.c
+++ b/saivpp/src/vppxlate/SaiIntfStats.c
@@ -47,39 +47,39 @@ static void handle_stat_one (const char *stat_name, uint32_t index,
 
   if (!strncmp(stat_name, DROPS, sizeof(DROPS)))
     {
-      st_p->drops = count;
+      st_p->drops += count;
     }
   else if (!strncmp(stat_name, PUNT, sizeof(PUNT)))
     {
-      st_p->punt = count;
+      st_p->punt += count;
     }
   else if (!strncmp(stat_name, IP4, sizeof(IP4)))
     {
-      st_p->ip4 = count;
+      st_p->ip4 += count;
     }
   else if (!strncmp(stat_name, IP6, sizeof(IP6)))
     {
-      st_p->ip6 = count;
+      st_p->ip6 += count;
     }
   else if (!strncmp(stat_name, RX_NO_BUF, sizeof(RX_NO_BUF)))
     {
-      st_p->rx_no_buf = count;
+      st_p->rx_no_buf += count;
     }
   else if (!strncmp(stat_name, RX_MISS, sizeof(RX_MISS)))
     {
-      st_p->rx_miss = count;
+      st_p->rx_miss += count;
     }
   else if (!strncmp(stat_name, RX_ERROR, sizeof(RX_ERROR)))
     {
-      st_p->rx_error = count;
+      st_p->rx_error += count;
     }
   else if (!strncmp(stat_name, TX_ERROR, sizeof(TX_ERROR)))
     {
-      st_p->tx_error = count;
+      st_p->tx_error += count;
     }
   else if (!strncmp(stat_name, MPLS, sizeof(MPLS)))
     {
-      st_p->mpls = count;
+      st_p->mpls += count;
     }
 }
 
@@ -90,43 +90,43 @@ static void handle_stat_two (const char *stat_name, uint32_t index,
 
   if (!strncmp(stat_name, RX, sizeof(RX)))
     {
-      st_p->rx = count1;
-      st_p->rx_bytes = count2;
+      st_p->rx += count1;
+      st_p->rx_bytes += count2;
     }
   else if (!strncmp(stat_name, TX, sizeof(TX)))
     {
-      st_p->tx = count1;
-      st_p->tx_bytes = count2;
+      st_p->tx += count1;
+      st_p->tx_bytes += count2;
     }
   else if (!strncmp(stat_name, RX_UNICAST, sizeof(RX_UNICAST)))
     {
-      st_p->rx_unicast = count1;
-      st_p->rx_unicast_bytes = count2;
+      st_p->rx_unicast += count1;
+      st_p->rx_unicast_bytes += count2;
     }
   else if (!strncmp(stat_name, RX_MULTICAST, sizeof(RX_MULTICAST)))
     {
-      st_p->rx_multicast = count1;
-      st_p->rx_multicast_bytes = count2;
+      st_p->rx_multicast += count1;
+      st_p->rx_multicast_bytes += count2;
     }
   else if (!strncmp(stat_name, RX_BROADCAST, sizeof(RX_BROADCAST)))
     {
-      st_p->rx_broadcast = count1;
-      st_p->rx_broadcast_bytes = count2;
+      st_p->rx_broadcast += count1;
+      st_p->rx_broadcast_bytes += count2;
     }
   else if (!strncmp(stat_name, TX_UNICAST, sizeof(TX_UNICAST)))
     {
-      st_p->tx_unicast = count1;
-      st_p->tx_unicast_bytes = count2;
+      st_p->tx_unicast += count1;
+      st_p->tx_unicast_bytes += count2;
     }
   else if (!strncmp(stat_name, TX_MULTICAST, sizeof(TX_MULTICAST)))
     {
-      st_p->tx_multicast = count1;
-      st_p->tx_multicast_bytes = count2;
+      st_p->tx_multicast += count1;
+      st_p->tx_multicast_bytes += count2;
     }
   else if (!strncmp(stat_name, TX_BROADCAST, sizeof(TX_BROADCAST)))
     {
-      st_p->tx_broadcast = count1;
-      st_p->tx_broadcast_bytes = count2;
+      st_p->tx_broadcast += count1;
+      st_p->tx_broadcast_bytes += count2;
     }
 }
 


### PR DESCRIPTION
### why
currently vpp is running in single thread. We noticed some packet drops at high input rate. And for unknown reason, orchagent is slow to respond to port state up notification.

### what this PR does
Allocate dedicated cpu cores to vpp worker threads and main thread. With this config, it requires the sonic VM has at least 4 vcpus.  

