### PR TITLE
Make azure pipeline build 21 days old vpp 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
         git clone https://gerrit.fd.io/r/vpp repo
         cp -vr sonic-platform-vpp/vppbld/plugins/* repo/src/plugins/
         cd repo
-	      git checkout $(git log --until "21 days ago" -1 --format="%h")
+        git checkout $(git log --until "21 days ago" -1 --format="%h")
         git apply ../sonic-platform-vpp/vppbld/vpp.patch
         make UNATTENDED=y PLATFORM=vpp install-deps install-ext-deps
         make UNATTENDED=y PLATFORM=vpp -j4 pkg-deb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,7 @@ stages:
         git clone https://gerrit.fd.io/r/vpp repo
         cp -vr sonic-platform-vpp/vppbld/plugins/* repo/src/plugins/
         cd repo
+	      git checkout $(git log --until "21 days ago" -1 --format="%h")
         git apply ../sonic-platform-vpp/vppbld/vpp.patch
         make UNATTENDED=y PLATFORM=vpp install-deps install-ext-deps
         make UNATTENDED=y PLATFORM=vpp -j4 pkg-deb


### PR DESCRIPTION
This is to be consistent with main sonic-vpp image build so we can keep single version of vpp.patch