### PR TITLE
Change router interface MTU to L3 payload

### DIFF
--- a/saivpp/src/SwitchStateBase.h
+++ b/saivpp/src/SwitchStateBase.h
@@ -952,15 +952,16 @@ namespace saivpp
                     _In_ sai_object_id_t object_id,
                     _In_ uint32_t vlan_id,
                     _In_ bool is_up);
+            // set ethernet interface mtu including L2 header
             sai_status_t vpp_set_port_mtu (
                     _In_ sai_object_id_t object_id,
                     _In_ uint32_t vlan_id,
                     _In_ uint32_t mtu);
+            // set sw interface mtu excluding L2 header
             sai_status_t vpp_set_interface_mtu (
                     _In_ sai_object_id_t object_id,
                     _In_ uint32_t vlan_id,
-                    _In_ uint32_t mtu,
-                    _In_ int type);
+                    _In_ uint32_t mtu);
 
             sai_status_t UpdatePort(
                    _In_ sai_object_id_t object_id,

--- a/saivpp/src/SwitchStateBaseRif.cpp
+++ b/saivpp/src/SwitchStateBaseRif.cpp
@@ -526,7 +526,7 @@ sai_status_t SwitchStateBase::vpp_set_port_mtu (
 	_In_ uint32_t mtu)
 {
     if (is_ip_nbr_active() == false) {
-	return SAI_STATUS_SUCCESS;
+        return SAI_STATUS_SUCCESS;
     }
 
     std::string ifname;
@@ -534,21 +534,20 @@ sai_status_t SwitchStateBase::vpp_set_port_mtu (
     if (vpp_get_hwif_name(object_id, vlan_id, ifname) == true) {
         const char *hwif_name = ifname.c_str();
 
-	hw_interface_set_mtu(hwif_name, mtu);
-	SWSS_LOG_NOTICE("Updating router interface mtu %s to %u", hwif_name,
-			mtu);
+        hw_interface_set_mtu(hwif_name, mtu);
+        SWSS_LOG_NOTICE("Updating router interface mtu %s to %u", hwif_name,
+                mtu);
     }
     return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t SwitchStateBase::vpp_set_interface_mtu (
         _In_ sai_object_id_t object_id,
-	_In_ uint32_t vlan_id,
-	_In_ uint32_t mtu,
-	int type)
+        _In_ uint32_t vlan_id,
+        _In_ uint32_t mtu)
 {
     if (is_ip_nbr_active() == false) {
-	return SAI_STATUS_SUCCESS;
+        return SAI_STATUS_SUCCESS;
     }
 
     std::string ifname;
@@ -556,9 +555,8 @@ sai_status_t SwitchStateBase::vpp_set_interface_mtu (
     if (vpp_get_hwif_name(object_id, vlan_id, ifname) == true) {
         const char *hwif_name = ifname.c_str();
 
-        sw_interface_set_mtu(hwif_name, mtu, type);
-	SWSS_LOG_NOTICE("Updating router interface mtu %s to %u", hwif_name,
-			mtu);
+        sw_interface_set_mtu(hwif_name, mtu);
+        SWSS_LOG_NOTICE("Updating router interface mtu %s to %u", hwif_name, mtu);
     }
     return SAI_STATUS_SUCCESS;
 }
@@ -1583,8 +1581,7 @@ sai_status_t SwitchStateBase::vpp_create_router_interface(
 
     if (attr_type_mtu != NULL)
     {
-        vpp_set_interface_mtu(obj_id, vlan_id, attr_type_mtu->value.u32, AF_INET);
-	vpp_set_interface_mtu(obj_id, vlan_id, attr_type_mtu->value.u32, AF_INET6);
+        vpp_set_interface_mtu(obj_id, vlan_id, attr_type_mtu->value.u32);
     }
 
     bool v4_is_up = false, v6_is_up = false;
@@ -1683,8 +1680,7 @@ sai_status_t SwitchStateBase::vpp_update_router_interface(
 
     if (attr_type_mtu != NULL)
     {
-        vpp_set_interface_mtu(obj_id, vlan_id, attr_type_mtu->value.u32, AF_INET);
-	vpp_set_interface_mtu(obj_id, vlan_id, attr_type_mtu->value.u32, AF_INET6);
+        vpp_set_interface_mtu(obj_id, vlan_id, attr_type_mtu->value.u32);
     }
 
     bool v4_is_up = false, v6_is_up = false;

--- a/saivpp/src/vppxlate/SaiVppXlate.c
+++ b/saivpp/src/vppxlate/SaiVppXlate.c
@@ -2612,7 +2612,7 @@ int vpp_sync_for_events ()
     return ret;
 }
 
-int sw_interface_set_mtu (const char *hwif_name, uint32_t mtu, int type)
+int sw_interface_set_mtu (const char *hwif_name, uint32_t mtu)
 {
     vat_main_t *vam = &vat_main;
     vl_api_sw_interface_set_mtu_t *mp;
@@ -2638,22 +2638,11 @@ int sw_interface_set_mtu (const char *hwif_name, uint32_t mtu, int type)
         VPP_UNLOCK();
         return -EINVAL;
     }
-    switch (type) {
-    case AF_INET:
-        mp->mtu[MTU_PROTO_API_IP4] = htonl(mtu);
-        break;
-
-    case AF_INET6:
-        mp->mtu[MTU_PROTO_API_IP6] = htonl(mtu);
-        break;
-    default:
-        VPP_UNLOCK();
-        return -EINVAL;
-    }
+    mp->mtu[MTU_PROTO_API_L3] = htonl(mtu);
 
     S (mp);
 
-    W (ret);
+    WR (ret);
 
     VPP_UNLOCK();
 

--- a/saivpp/src/vppxlate/SaiVppXlate.h
+++ b/saivpp/src/vppxlate/SaiVppXlate.h
@@ -273,7 +273,7 @@ typedef enum {
     extern int interface_ip_address_add_del(const char *hw_ifname, vpp_ip_route_t *prefix, bool is_add);
     extern int interface_set_state (const char *hwif_name, bool is_up);
     extern int hw_interface_set_mtu(const char *hwif_name, uint32_t mtu);
-    extern int sw_interface_set_mtu(const char *hwif_name, uint32_t mtu, int type);
+    extern int sw_interface_set_mtu(const char *hwif_name, uint32_t mtu);
     extern int sw_interface_set_mac(const char *hwif_name, uint8_t *mac_address);
     extern int sw_interface_ip6_enable_disable(const char *hwif_name, bool enable);
     extern int ip_vrf_add(uint32_t vrf_id, const char *vrf_name, bool is_ipv6);


### PR DESCRIPTION
### why
vpp supports per protocol mtu: L3, ipv4, ipv6 and mpls. However, each time we set mtu for one protocol, it resets mtu of other protocols to 0. For a packet to be forwarded, it checks the mtu for the corresponding protocol. If the mtu is 0, it checks mtu of L3. If L3 is also 0, it uses 9000 as default. (see https://github.com/FDio/vpp/blob/master/src/vnet/interface_funcs.h#L317). This causes sonic-mgmt mtu test failed at 9114, which sets router interface MTU to 9100.
### what this PR does
sonic router interface doesn't support per protocol MTU. We set the mtu to protocol L3 in vpp, which applies to all L3 payloads. 