### PR TITLE
Fix VPP Build

### DIFF
--- a/vppbld/vppbld-docker/Dockerfile-bookworm.j2
+++ b/vppbld/vppbld-docker/Dockerfile-bookworm.j2
@@ -17,7 +17,7 @@ COPY /debs/{{ pkg }} /app
 {% endfor %} 
 RUN apt-get update 
 
-RUN apt-get install -f -y make curl sudo git
+RUN apt-get install -f -y make curl sudo git clang
 
 {% for pkg in VPP_DOCKER_DEBS.split() %}
 RUN dpkg -i /app/{{ pkg }} || apt-get install -f -y

--- a/vppbld/vppbld-docker/run_build.sh
+++ b/vppbld/vppbld-docker/run_build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd /vpp
-make UNATTENDED=y PLATFORM=vpp install-dep && make UNATTENDED=y PLATFORM=vpp -j4 pkg-deb
+make UNATTENDED=y PLATFORM=vpp install-dep && make UNATTENDED=y PLATFORM=vpp install-ext-dep && make UNATTENDED=y PLATFORM=vpp -j4 pkg-deb
 echo ret:$?


### PR DESCRIPTION
**Problem**
Latest VPP build is failing as it is using clang by default now.

**Fix**
Update docker vpp build environment and command to allow build with clang.