### PR TITLE
Move vpp upstream version forward to pass buggy version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
         git clone https://gerrit.fd.io/r/vpp repo
         cp -vr sonic-platform-vpp/vppbld/plugins/* repo/src/plugins/
         cd repo
-        git checkout $(git log --until "21 days ago" -1 --format="%h")
+        git checkout $(git log --until "7 days ago" -1 --format="%h")
         git apply ../sonic-platform-vpp/vppbld/vpp.patch
         make UNATTENDED=y PLATFORM=vpp install-deps install-ext-deps
         make UNATTENDED=y PLATFORM=vpp -j4 pkg-deb

--- a/vppbld/Makefile
+++ b/vppbld/Makefile
@@ -17,7 +17,7 @@ SHELL = /bin/bash
 
 VPP_URL = https://gerrit.fd.io/r/vpp
 VPP_SHA =
-VPP_LAG = 10
+VPP_LAG = 7
 USER = $(shell id -un)
 UID = $(shell id -u)
 GUID = $(shell id -g)

--- a/vppbld/vpp.patch
+++ b/vppbld/vpp.patch
@@ -28,8 +28,8 @@ index b9285971f..c38acc598 100644
  endef
  
  define  xdp-tools_build_cmds
--	@cd ${xdp-tools_src_dir} && $(MAKE) V=1 BUILD_STATIC_ONLY=y > $(xdp-tools_build_log)
-+	@cd ${xdp-tools_src_dir} && $(MAKE) FORCE_SUBDIR_LIBBPF=1 V=1 BUILD_STATIC_ONLY=y > $(xdp-tools_build_log)
+-       @cd ${xdp-tools_src_dir} && $(MAKE) CC=gcc V=1 BUILD_STATIC_ONLY=y > $(xdp-tools_build_log)
++       @cd ${xdp-tools_src_dir} && $(MAKE) CC=gcc FORCE_SUBDIR_LIBBPF=1 V=1 BUILD_STATIC_ONLY=y > $(xdp-tools_build_log)
  endef
  
  define  xdp-tools_install_cmds


### PR DESCRIPTION
vpp commit https://github.com/FDio/vpp/commit/884ab372500c9937d4ae21e0bc77ea51e6144307 introduces an error causing build failure. It is fixed later on by https://github.com/FDio/vpp/commit/aa4dfccc98dce64393f390201ea49152d2cb9d87. We need to move vpp version from upstream to get around the buggy commit