### PR TITLE
Allow missing SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR.

### DIFF
--- a/saivpp/src/SwitchStateBaseSRv6.cpp
+++ b/saivpp/src/SwitchStateBaseSRv6.cpp
@@ -124,7 +124,9 @@ sai_status_t TunnelManagerSRv6::fill_my_sid_entry(
     my_sid.behavior = (uint32_t) attr.value.u32;
 
     attr.id = SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR;
-    CHECK_STATUS_W_MSG(my_sid_obj->get_attr(attr), "Could not get endpoint behavior flavor.");
+    if(my_sid_obj->get_attr(attr) != SAI_STATUS_SUCCESS) {
+        attr.value.u32 = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_NONE;
+    }
     if(attr.value.u32 == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP ||
        attr.value.u32 == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USP ||
        attr.value.u32 == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD ||


### PR DESCRIPTION
If SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR is SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_NONE Orchagent will not set the attribute: https://github.com/sonic-net/sonic-swss/blame/8c2b2ac565c4e8a4683ee0d3668459f4d9c5032c/orchagent/srv6orch.cpp#L1349

Updating sonic-vpp to handle this scenario and continue with programming VPP. 