### PR TITLE
Fix create_loopback_instance occasional failure

### DIFF
--- a/saivpp/src/vppxlate/SaiVppXlate.c
+++ b/saivpp/src/vppxlate/SaiVppXlate.c
@@ -1622,7 +1622,7 @@ static int __create_loopback_instance (vat_main_t *vam, u32 instance)
     /* create loopback interfaces from vnet/interface_cli.c */
     S (mp);
 
-    W (ret);
+    WR (ret);
 
     VPP_UNLOCK();
 


### PR DESCRIPTION
### why
Occasionally we saw test_bgp_sentinel failed due to some routes not advertised to the peers. This is due to the loopback address used as source of the routes is failed to create.
2025 May 12 15:52:48.833647 vlab-vpp-01 WARNING bgp#zebra[58]: [VYKYC-709DP] default(0:254):100.1.0.17/32: Route install failed
2025 May 12 15:52:48.942392 vlab-vpp-01 ERR bgp#zebra[58]: [HSYZM-HV7HF] Extended Error: Invalid prefsrc address
2025 May 12 15:52:48.942392 vlab-vpp-01 ERR bgp#zebra[58]: [WVJCK-PPMGD][EC 4043309093] netlink-dp (NS 0) error: Invalid argument, type=RTM_NEWROUTE(24), seq=1002, pid=3269206028

From syslog, we can see related error messages.
2025 May 12 15:52:48.597485 vlab-vpp-01 NOTICE syncd#syncd#syncd: :- threadFunction: time span 975 ms for 'create:SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"10.1.0.32/32","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000002"}'
2025 May 12 15:52:48.630803 vlab-vpp-01 ERR syncd#syncd#syncd: :- vpp_add_lpb_intf_ip_addr: create_loopback_instance returned error: -99

This is because __create_loopback_instance uses W, which returns when it receives any event from vpp socket. vpp sends unsolicited interface up event when loopback interface is created. If this event is returned before the ACK of create_loopback_instance, W will return it, which carries a value (-99) indicating error. 

### what this PR does
change W to WR, which will skip unsolicited events until it gets an API call reply or timeout.