### PR TITLE
Add docker-sonic-vpp target to the platform rules

### DIFF
--- a/rules.dep
+++ b/rules.dep
@@ -23,3 +23,4 @@ include $(PLATFORM_RULES)/one-image.dep
 include $(PLATFORM_RULES)/onie.dep
 include $(PLATFORM_RULES)/kvm-image.dep
 include $(PLATFORM_RULES)/raw-image.dep
+include $(PLATFORM_RULES)/docker-sonic-vpp.dep

--- a/rules.mk
+++ b/rules.mk
@@ -25,5 +25,6 @@ include $(PLATFORM_RULES)/one-image.mk
 include $(PLATFORM_RULES)/onie.mk
 include $(PLATFORM_RULES)/kvm-image.mk
 include $(PLATFORM_RULES)/raw-image.mk
+include $(PLATFORM_RULES)/docker-sonic-vpp.mk
 
 SONIC_ALL += $(SONIC_ONE_IMAGE) $(SONIC_KVM_IMAGE) $(DOCKER_SONIC_VPP) $(SONIC_RAW_IMAGE)


### PR DESCRIPTION
The target is mentioned by build instructions in the README.md, but not enabled by default.