### PR TITLE
Fix supervisor-proc-exit-listener not found build error

### DIFF
--- a/docker-gbsyncd-vpp/Dockerfile.j2
+++ b/docker-gbsyncd-vpp/Dockerfile.j2
@@ -26,7 +26,6 @@ debs/{{ deb }}{{' '}}
 COPY ["start.sh", "/usr/bin/"]
 
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
-COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
 ## Clean up

--- a/docker-gbsyncd-vpp/supervisord.conf
+++ b/docker-gbsyncd-vpp/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name gbsyncd
+command=/usr/local/bin/supervisor-proc-exit-listener --container-name gbsyncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected

--- a/docker-syncd-vpp/Dockerfile.j2
+++ b/docker-syncd-vpp/Dockerfile.j2
@@ -26,7 +26,6 @@ debs/{{ deb }}{{' '}}
 COPY ["start.sh", "/usr/bin/"]
 
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
-COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
 COPY scripts/vpp_hostif.sh /usr/local/bin/

--- a/docker-syncd-vpp/supervisord.conf
+++ b/docker-syncd-vpp/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/local/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected


### PR DESCRIPTION
Fix supervisor-proc-exit-listener not found build error.

Build error caused by https://github.com/sonic-net/sonic-buildimage/pull/23513.