### PR TITLE
Increase vpp dpdk tx buffer to handle burst

### DIFF
--- a/docker-syncd-vpp/scripts/vpp_init.sh
+++ b/docker-syncd-vpp/scripts/vpp_init.sh
@@ -52,7 +52,11 @@ cp $STARTUP_TMPL $TMP_FILE || error "Failed to copy template file"
 [ "$NO_LINUX_NL" == "y" ] && sed -i -e 's/plugin linux_nl_plugin/#plugin linux_nl_plugin/g' $TMP_FILE
 
 IDX=0
-upd_startup "dpdk {"
+upd_startup """dpdk {
+	dev default {
+	    num-tx-desc 4096
+	}
+	"""
 for port in ${portlist[@]};
 do
     if eval ip link show type veth dev $port >& /dev/null; then


### PR DESCRIPTION
### why
in sonic-mgmt test_ip_packet, test cases generate 1000 packets and verify received packets in ptf. In azure sonic-vpp PR checker, we saw intermittent failure due to packet drop with reason "dpdk tx failure". This is because KVM virtio NIC could not drain the packets fast enough. When tx ring buffer is full, packets will be dropped with "dpdk tx failure".

### what this PR does
increase num-tx-desc to accommodate the burst of 1000 packets