### PR TITLE
chore(docs): clarify j2cli installation prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,27 @@ This repo contains  scripts, Makefiles, configuration file, Docker files etc to 
 ```
 sudo apt-get install -y make automake autoconf
 sudo apt install -y python3-pip
-sudo pip3 install j2cli
 ```
+
+ * Confirm whether `j2cli` is already installed:
+
+```
+j2 --version
+```
+
+If `j2` is not found, install `j2cli` using one of the following methods:
+
+```
+sudo apt install -y j2cli
+```
+
+or:
+
+```
+pip3 install --user j2cli
+```
+
+If you install `j2cli` with `pip3 --user`, make sure your user's local binary directory (for example, `$HOME/.local/bin`) is in your `PATH`.
 
  * Install [Docker](https://docs.docker.com/engine/install/) and configure your system to allow running the 'docker' command without 'sudo':
     * Add current user to the docker group: `sudo gpasswd -a ${USER} docker`


### PR DESCRIPTION
## Summary
- Replaces the sudo pip3 install j2cli prerequisite with safer installation guidance.
- Asks readers to first check whether j2cli is already installed using j2 --version.
- Adds a reminder that pip user installs may require $HOME/.local/bin to be added to PATH.

## Motivation:
Using `sudo pip3 install ...` is not recommended because it can modify the system Python environment as root and conflict with packages managed by the OS package manager. The updated instructions prefer distro packages or user-local pip installation.