### PR TITLE
Fix nightly branch.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ schedules:
   displayName: Daily midnight build
   branches:
     include:
-    - main
+    - master
   always: true
 
 parameters:


### PR DESCRIPTION
Nightly platform vpp branch was using 'main' instead of the default 'master' branch in the nightly build. Updating it to master so it correctly picks up all latest changes.