### PR TITLE
ip_validate plugin: restrict checks to unicast traffic

### DIFF
--- a/rules/vpp.mk
+++ b/rules/vpp.mk
@@ -1,7 +1,7 @@
 # libvpp package
 
 VPP_VERSION_BASE = 2510
-VPP_VERSION = $(VPP_VERSION_BASE)-0.3
+VPP_VERSION = $(VPP_VERSION_BASE)-0.4
 VPP_VERSION_SONIC = $(VPP_VERSION)+b1sonic1
 VPP_SRC_PATH = platform/vpp/vppbld
 

--- a/rules/vpp.mk
+++ b/rules/vpp.mk
@@ -1,7 +1,7 @@
 # libvpp package
 
 VPP_VERSION_BASE = 2510
-VPP_VERSION = $(VPP_VERSION_BASE)-0.4
+VPP_VERSION = $(VPP_VERSION_BASE)-0.3
 VPP_VERSION_SONIC = $(VPP_VERSION)+b1sonic1
 VPP_SRC_PATH = platform/vpp/vppbld
 

--- a/vppbld/plugins/ip_validate/FEATURE.yaml
+++ b/vppbld/plugins/ip_validate/FEATURE.yaml
@@ -4,7 +4,8 @@ maintainer: Akeel Ali <akeali@cisco.com>
 features:
   - Validates incoming IP packets and drops those with invalid
     source/destination addresses. Runs on the ip4-unicast and
-    ip6-unicast feature arcs.
+    ip6-unicast feature arcs, and only inspects unicast packets;
+    broadcast and multicast traffic is passed through unchanged.
   - When the plugin is enabled, filtering is automatically
     applied to every interface.
   - IPv4 source filtering:

--- a/vppbld/plugins/ip_validate/ip4_validate_node.c
+++ b/vppbld/plugins/ip_validate/ip4_validate_node.c
@@ -88,6 +88,17 @@ ip4_validate_x1 (vlib_buffer_t *b, u16 *next)
 
   vnet_feature_next (&feat_next, b);
 
+  src = clib_net_to_host_u32 (ip->src_address.as_u32);
+  dst = clib_net_to_host_u32 (ip->dst_address.as_u32);
+
+  /* Only validate unicast packets */
+  /* skip broadcast (255.255.255.255) and multicast (224.0.0.0/4) */
+  if (PREDICT_FALSE (dst == 0xFFFFFFFFu || (dst >> 28) == 0xE))
+    {
+      *next = (u16) feat_next;
+      return IP4_VALIDATE_ERROR_VALID;
+    }
+
   /*
    * L2 check: unicast IP but multicast/broadcast ETH dst.
    * Use ethernet_buffer_get_header() which correctly handles VLAN-tagged
@@ -101,9 +112,6 @@ ip4_validate_x1 (vlib_buffer_t *b, u16 *next)
 	return IP4_VALIDATE_ERROR_L2_MCAST_BCAST;
       }
   }
-
-  src = clib_net_to_host_u32 (ip->src_address.as_u32);
-  dst = clib_net_to_host_u32 (ip->dst_address.as_u32);
 
   /* SRC checks */
 

--- a/vppbld/plugins/ip_validate/ip6_validate_node.c
+++ b/vppbld/plugins/ip_validate/ip6_validate_node.c
@@ -97,6 +97,14 @@ ip6_validate_x1 (vlib_buffer_t *b, u16 *next)
 
   vnet_feature_next (&feat_next, b);
 
+  /* Only validate unicast packets */
+  /* skip multicast (ff00::/8) */
+  if (PREDICT_FALSE (ip->dst_address.as_u8[0] == 0xFF))
+    {
+      *next = (u16) feat_next;
+      return IP6_VALIDATE_ERROR_VALID;
+    }
+
   /*
    * L2 check: unicast IP but multicast/broadcast ETH dst.
    * Use ethernet_buffer_get_header() which correctly handles VLAN-tagged

--- a/vppbld/plugins/ip_validate/test/test_ip_validate.py
+++ b/vppbld/plugins/ip_validate/test/test_ip_validate.py
@@ -131,6 +131,27 @@ class TestIpValidate(VppTestCase):
         capture = pg1.get_capture(1)
         self.assertEqual(len(capture), 1)
 
+    def send_and_assert_passed_validate(self, pkt, node):
+        """Send a packet and verify it was passed (not dropped) by the
+        ip_validate plugin. Confirms the node's VALID counter incremented;
+        if the validate node had dropped the packet it would have bumped a
+        different error counter instead.  Useful for traffic that the plugin
+        should ignore (e.g. broadcast/multicast) but that may still be
+        dropped further downstream."""
+        valid_counter = "/err/%s/valid packets" % node
+        valid_before = self.statistics.get_err_counter(valid_counter)
+
+        self.pg_interfaces[0].add_stream([pkt])
+        self.pg_interfaces[1].enable_capture()
+        self.pg_start()
+
+        valid_after = self.statistics.get_err_counter(valid_counter)
+        self.assertGreater(
+            valid_after, valid_before,
+            "%s did not pass packet (VALID counter %s did not increment)"
+            % (node, valid_counter),
+        )
+
     # ================================================================
     # IPv4 L2 check tests
     # ================================================================
@@ -158,6 +179,21 @@ class TestIpValidate(VppTestCase):
         self.send_and_assert_dropped(
             pkt, "/err/ip4-validate/unicast IP with multicast~broadcast L2 destination"
         )
+
+    # ================================================================
+    # IPv4 unicast-only early-out tests (broadcast/multicast pass through)
+    # ================================================================
+
+    def test_ipv4_limited_broadcast_passthrough(self):
+        """IPv4: DHCP-style limited broadcast (255.255.255.255) -> passthrough"""
+        pg0 = self.pg_interfaces[0]
+        pkt = (
+            Ether(src=pg0.remote_mac, dst="ff:ff:ff:ff:ff:ff")
+            / IP(src="0.0.0.0", dst="255.255.255.255")
+            / UDP(sport=68, dport=67)
+            / Raw(b"\xa5" * 100)
+        )
+        self.send_and_assert_passed_validate(pkt, node="ip4-validate")
 
     # ================================================================
     # IPv4 SRC address check tests


### PR DESCRIPTION
## Problem
Report of DHCP discovery traffic being erroneously dropped by the ip_validate plugin

```
00:03:47:907604: ip4-input
  UDP: 0.0.0.0 -> 255.255.255.255
    tos 0x10, ttl 128, length 328, checksum 0x3996 dscp unknown ecn NON_ECN
    fragment id 0x0000
  UDP: 68 -> 67
    length 308, checksum 0xd9d3
00:03:47:907630: ip4-validate
  IP4-VALIDATE: sw_if_index 25 next 0 src 0.0.0.0 dst 255.255.255.255
00:03:47:907660: error-drop
  rx:bvi10
00:03:47:907666: drop
  null-node: blackholed packets 
```

```
   53            ip4-validate           unicast IP with multicast~broadcast   error  
```

## RC
Plugin IP checks should only be applied to unicast traffic and let broadcast/multicast traffic passthrough unchanged.

## Fix
- Restrict the plugin checks to only unicast traffic. 
- Add a test to ensure broadcast traffic like DHCP discovery traverses the plugin without being dropped

## Test
```
==============================================================================
IP Packet Validation Test Case [main thread only]
==============================================================================
IPv4: after disabling feature, invalid packets are forwarded        OK
IPv6: after disabling feature, invalid packets are forwarded        OK
IPv4: DST=127.0.0.1 -> drop                                         OK
IPv6: DST=::1 -> drop                                               OK
IPv4: DST=169.254.1.1 -> drop                                       OK
IPv4: SRC=0.0.0.0 -> drop                                           OK
IPv6: DST=:: -> drop                                                OK
IPv6: SRC=:: -> drop                                                OK

===> IPv4: DHCP-style limited broadcast (255.255.255.255) -> passthrough OK <===

IPv4: mixed valid and invalid packets in one stream                 OK
IPv6: mixed valid and invalid packets in one stream                 OK
IPv4: SRC=240.1.1.1 -> drop                                         OK
IPv4: SRC=127.0.0.1 -> drop                                         OK
IPv6: SRC=::1 -> drop                                               OK
IPv4: SRC=224.1.1.1 -> drop                                         OK
IPv6: SRC=ff02::1 -> drop                                           OK
IPv4: SRC=169.254.1.1 -> drop                                       OK
IPv4: unicast IP dst with broadcast ETH dst (ff:ff:ff) -> drop      OK
IPv4: unicast IP dst with multicast ETH dst (01:00:5e) -> drop      OK
IPv6: unicast IP dst with broadcast ETH dst -> drop                 OK
IPv6: unicast IP dst with multicast ETH dst -> drop                 OK
IPv4: valid packets traverse node and increment VALID counter       OK
IPv4: valid SRC and DST -> forwarded                                OK
IPv6: valid packets traverse node and increment VALID counter       OK
IPv6: valid SRC and DST -> forwarded                                OK
IPv4: VLAN-tagged unicast IP with multicast ETH dst -> drop         OK
IPv4: VLAN-tagged valid packet -> forwarded                         OK

==============================================================================
TEST RESULTS:
    Scheduled tests: 27
     Executed tests: 27
       Passed tests: 27
==============================================================================

Test run was successful
```