### PR TITLE
vppcfgd: use yaml.SafeLoader in read_constants()

### DIFF
--- a/platform/mkrules/src/sonic-vppcfgd/vppcfgd/utils.py
+++ b/platform/mkrules/src/sonic-vppcfgd/vppcfgd/utils.py
@@ -40,7 +40,7 @@ def run_command(command, shell=False, hide_errors=False):
 def read_constants():
     """ Read file with constants values from /etc/sonic/constants.yml """
     with open('/etc/sonic/constants.yml') as fp:
-        content = yaml.load(fp) # FIXME: , Loader=yaml.FullLoader)
+        content = yaml.load(fp, Loader=yaml.SafeLoader)
         if "constants" not in content:
             log_crit("/etc/sonic/constants.yml doesn't have 'constants' key")
             raise Exception("/etc/sonic/constants.yml doesn't have 'constants' key")


### PR DESCRIPTION
## Why I did it

`yaml.load()` without a Loader argument defaults to the unsafe FullLoader (or worse, on PyYAML < 5.1), permitting arbitrary Python object instantiation via `!!python/object` tags in the YAML input.

## How I did it

Pass `Loader=yaml.SafeLoader` explicitly in `read_constants()` in `vppcfgd/utils.py`.

## How to verify it

No unit tests exist for this module. The change is a one-line fix replacing `yaml.load(fp)` with `yaml.load(fp, Loader=yaml.SafeLoader)`.

## Description for the changelog

vppcfgd: use yaml.SafeLoader to prevent unsafe YAML deserialization
