### PR TITLE
Add `sonic_fib_init` plugin

### DIFF
--- a/docker-sonic-vpp/conf/startup.conf.tmpl
+++ b/docker-sonic-vpp/conf/startup.conf.tmpl
@@ -247,6 +247,7 @@ plugins {
         plugin vxlan_plugin.so { enable }
 	plugin tunterm_acl_plugin.so { enable }
 	plugin ip_validate_plugin.so { enable }
+	plugin sonic_fib_init_plugin.so { enable }
 
 	## Enable all plugins by default and then selectively disable specific plugins
 	# plugin dpdk_plugin.so { disable }

--- a/docker-syncd-vpp/conf/startup.conf.tmpl
+++ b/docker-syncd-vpp/conf/startup.conf.tmpl
@@ -235,6 +235,7 @@ plugins {
         plugin vxlan_plugin.so { enable }
 	plugin tunterm_acl_plugin.so { enable }
 	plugin ip_validate_plugin.so { enable }
+	plugin sonic_fib_init_plugin.so { enable }
 
 	## Enable all plugins by default and then selectively disable specific plugins
 	# plugin dpdk_plugin.so { disable }

--- a/rules/vpp.mk
+++ b/rules/vpp.mk
@@ -1,7 +1,7 @@
 # libvpp package
 
 VPP_VERSION_BASE = 2510
-VPP_VERSION = $(VPP_VERSION_BASE)-0.3
+VPP_VERSION = $(VPP_VERSION_BASE)-0.4
 VPP_VERSION_SONIC = $(VPP_VERSION)+b1sonic1
 VPP_SRC_PATH = platform/vpp/vppbld
 

--- a/vppbld/plugins/sonic_fib_init/CMakeLists.txt
+++ b/vppbld/plugins/sonic_fib_init/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Microsoft and/or its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_vpp_plugin(sonic_fib_init
+  SOURCES
+  sonic_fib_init.c
+
+  API_FILES
+  sonic_fib_init.api
+)

--- a/vppbld/plugins/sonic_fib_init/FEATURE.yaml
+++ b/vppbld/plugins/sonic_fib_init/FEATURE.yaml
@@ -1,0 +1,13 @@
+---
+name: SONiC FIB Init
+maintainer: Longxiang Lyu <lolv@microsoft.com>
+features:
+  - Removes the built-in FIB_SOURCE_SPECIAL drop entry for
+    240.0.0.0/4 (IPv4 class E reserved range) from the default
+    IPv4 FIB at VPP startup so that SONiC-installed routes win the
+    longest-prefix match instead of the hard-coded VPP drop.
+  - Exposes a `sonic_fib_strip_specials { vrf_id }` binary API for
+    the SAI shim to invoke after creating additional IPv4 VRFs, so
+    the same cleanup is applied to user-created tables.
+description: "SONiC-specific FIB initialization adjustments"
+state: experimental

--- a/vppbld/plugins/sonic_fib_init/sonic_fib_init.api
+++ b/vppbld/plugins/sonic_fib_init/sonic_fib_init.api
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Microsoft and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option version = "1.0.0";
+
+/** \brief Strip the built-in FIB_SOURCE_SPECIAL drop entries that the
+    plugin manages from the IPv4 FIB identified by vrf_id (table_id).
+
+    This is intended to be called by the SAI shim immediately after
+    creating a VPP IPv4 FIB table (SAI virtual_router create) so that
+    SONiC-installed routes are not pre-empted by the hard-coded VPP
+    drop entries (currently 240.0.0.0/4).
+
+    @param client_index - opaque cookie to identify the sender
+    @param context      - sender context, to match reply w/ request
+    @param vrf_id       - the IPv4 table_id whose specials should be
+                          stripped (0 == default VRF)
+*/
+autoreply define sonic_fib_strip_specials
+{
+  u32 client_index;
+  u32 context;
+  u32 vrf_id;
+};

--- a/vppbld/plugins/sonic_fib_init/sonic_fib_init.c
+++ b/vppbld/plugins/sonic_fib_init/sonic_fib_init.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Microsoft and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * sonic_fib_init: remove built-in FIB_SOURCE_SPECIAL drop entries that
+ * conflict with SONiC datapath expectations.
+ *
+ * Background
+ * ----------
+ * VPP installs hard-coded drop entries into every IPv4 FIB at creation
+ * time (see src/vnet/fib/ip4_fib.c :: ip4_specials[]). One of them is
+ * 240.0.0.0/4 (the IPv4 "class E reserved" range) installed with
+ * FIB_SOURCE_SPECIAL + FIB_ENTRY_FLAG_DROP. FIB_SOURCE_SPECIAL is the
+ * highest-priority FIB source (FIB_SOURCE_FIRST in fib_source.h) and
+ * cannot be overridden via the FIB API or `ip route` CLI.
+ *
+ * Forwarding decisions for these address ranges should be governed by
+ * the routes SONiC programs into the FIB, not by a hard-coded drop in
+ * VPP. Other SONiC platforms (BCM, MLNX) do not impose this filter, so
+ * we strip the SPECIAL drop here to maintain cross-platform parity and
+ * let SONiC-installed routes win the longest-prefix match.
+ *
+ * Implementation
+ * --------------
+ * fib_table_entry_special_remove() is C-only (not exposed by VPP's
+ * built-in binary API), so the cleanup must run from inside VPP.
+ *
+ * - The default VRF (fib 0) is created during VPP startup before any
+ *   external client connects, so we strip its SPECIAL drop once via
+ *   VLIB_MAIN_LOOP_ENTER_FUNCTION (after all VLIB_INIT_FUNCTIONs, so
+ *   the FIB and its SPECIAL entry are already in place).
+ *
+ * - For VRFs created at runtime (SAI virtual_router create routed
+ *   through the SAI shim's `ip_table_add_del`), the shim invokes our
+ *   `sonic_fib_strip_specials` binary API immediately after the table
+ *   is created. The handler looks up the fib_index for the requested
+ *   table_id and removes the SPECIAL drop.
+ *
+ * Note on 224.0.0.0/4: the matching multicast drop entry is left
+ * intact intentionally; SONiC does not currently require forwarding
+ * into that range and removing it could affect IGMP/PIM behaviour.
+ */
+
+#include <vnet/vnet.h>
+#include <vnet/plugin/plugin.h>
+#include <vnet/fib/fib_table.h>
+#include <vpp/app/version.h>
+
+#include <sonic_fib_init/sonic_fib_init.h>
+
+#include <vlibapi/api.h>
+#include <vlibmemory/api.h>
+
+#include <sonic_fib_init/sonic_fib_init.api_enum.h>
+#include <sonic_fib_init/sonic_fib_init.api_types.h>
+
+#define REPLY_MSG_ID_BASE sm->msg_id_base
+#include <vlibapi/api_helper_macros.h>
+
+VLIB_PLUGIN_REGISTER () = {
+  .version = SONIC_FIB_INIT_PLUGIN_BUILD_VER,
+  .description = "SONiC FIB init: remove implicit class-E drop",
+};
+
+sonic_fib_init_main_t sonic_fib_init_main;
+
+static void
+sonic_fib_init_strip_v4 (u32 fib_index)
+{
+  fib_prefix_t pfx;
+
+  /* IPv4: 240.0.0.0/4 (class E reserved) -- drop installed by
+   * ip4_fib_hash_load_specials() with FIB_SOURCE_SPECIAL. */
+  clib_memset (&pfx, 0, sizeof (pfx));
+  pfx.fp_proto = FIB_PROTOCOL_IP4;
+  pfx.fp_len = 4;
+  pfx.fp_addr.ip4.data_u32 = clib_host_to_net_u32 (0xf0000000);
+  fib_table_entry_special_remove (fib_index, &pfx, FIB_SOURCE_SPECIAL);
+}
+
+static void
+vl_api_sonic_fib_strip_specials_t_handler (
+  vl_api_sonic_fib_strip_specials_t *mp)
+{
+  sonic_fib_init_main_t *sm = &sonic_fib_init_main;
+  vl_api_sonic_fib_strip_specials_reply_t *rmp;
+  int rv = 0;
+  u32 vrf_id = ntohl (mp->vrf_id);
+  u32 fib_index;
+
+  fib_index = fib_table_find (FIB_PROTOCOL_IP4, vrf_id);
+  if (fib_index == ~0)
+    {
+      rv = VNET_API_ERROR_NO_SUCH_FIB;
+      goto done;
+    }
+
+  sonic_fib_init_strip_v4 (fib_index);
+
+done:
+  REPLY_MACRO (VL_API_SONIC_FIB_STRIP_SPECIALS_REPLY);
+}
+
+/* API definitions */
+#include <sonic_fib_init/sonic_fib_init.api.c>
+
+static clib_error_t *
+sonic_fib_init_init (vlib_main_t *vm)
+{
+  sonic_fib_init_main_t *sm = &sonic_fib_init_main;
+
+  sm->msg_id_base = setup_message_id_table ();
+
+  return 0;
+}
+
+VLIB_INIT_FUNCTION (sonic_fib_init_init);
+
+static clib_error_t *
+sonic_fib_init_main_loop_enter (vlib_main_t *vm)
+{
+  /* fib 0 is the default VRF, created during VPP startup. Additional
+   * VRFs are handled via the sonic_fib_strip_specials API. */
+  sonic_fib_init_strip_v4 (0);
+  return 0;
+}
+
+VLIB_MAIN_LOOP_ENTER_FUNCTION (sonic_fib_init_main_loop_enter);

--- a/vppbld/plugins/sonic_fib_init/sonic_fib_init.h
+++ b/vppbld/plugins/sonic_fib_init/sonic_fib_init.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Microsoft and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __included_sonic_fib_init_h__
+#define __included_sonic_fib_init_h__
+
+#include <vnet/vnet.h>
+
+typedef struct
+{
+  /* API message ID base */
+  u16 msg_id_base;
+} sonic_fib_init_main_t;
+
+extern sonic_fib_init_main_t sonic_fib_init_main;
+
+#define SONIC_FIB_INIT_PLUGIN_BUILD_VER "1.0"
+
+#endif /* __included_sonic_fib_init_h__ */


### PR DESCRIPTION
sonic_fib_init: new VPP plugin to strip built-in 240.0.0.0/4 SPECIAL drop

VPP installs a FIB_SOURCE_SPECIAL drop entry for 240.0.0.0/4 (class E
reserved) into every IPv4 FIB at table creation time (see
ip4_fib_hash_load_specials). FIB_SOURCE_SPECIAL is the highest-priority
source in the FIB, so any route SONiC programs that covers this range
(e.g. an IP-in-IP decap tunnel destination, or a default route) is
silently pre-empted by the drop and the traffic is black-holed. This
breaks decap test cases that target 240.0.0.0/4.

`fib_table_entry_special_remove()` is the supported way to remove the
entry, but it is a C-only API with no .api binding, so it cannot be
invoked from the SAI shim directly.

This plugin bridges that gap:

  * VLIB_MAIN_LOOP_ENTER_FUNCTION strips 240/4 from fib 0 (the default
    VRF, created during VPP startup) exactly once, after all
    VLIB_INIT_FUNCTIONs have run and before the main packet poll loop
    begins.

  * `sonic_fib_strip_specials { vrf_id }` binary API lets the SAI shim
    request the same cleanup for VRFs created at runtime
    (SAI virtual_router create -> ip_table_add_del). The handler
    resolves vrf_id -> fib_index via fib_table_find() and applies the
    strip; missing tables are reported via the autoreply status.


Plugin layout:
  vppbld/plugins/sonic_fib_init/
    sonic_fib_init.c        - init + main-loop-enter hooks, API handler
    sonic_fib_init.h        - sonic_fib_init_main_t (msg_id_base)
    sonic_fib_init.api      - sonic_fib_strip_specials autoreply
    CMakeLists.txt          - add_vpp_plugin(sonic_fib_init ...)
    FEATURE.yaml            - feature documentation

Both startup.conf templates (docker-sonic-vpp, docker-syncd-vpp) are
updated to load sonic_fib_init_plugin.so.

Verification:

```
vpp# show ip fib 240.0.0.0
ipv4-VRF:0, fib_index:0, flow hash:[src dst sport dport proto ] epoch:0 flags:none locks:[adjacency:1, recursive-resolution:8, default-route:1, ]
0.0.0.0/0 fib:0 index:0 locks:3
  API refs:1 src-flags:added,contributing,active,
    path-list:[242] locks:12798 flags:shared,popular, uPRF-list:168 len:4 itfs:[65, 66, 67, 68, ]
      path:[406] pl-index:242 ip4 weight=1 pref=0 recursive:  oper-flags:resolved,
        via 10.0.0.57 in fib:0 via-fib:111 via-dpo:[dpo-load-balance:112]
      path:[407] pl-index:242 ip4 weight=1 pref=0 recursive:  oper-flags:resolved,
        via 10.0.0.59 in fib:0 via-fib:120 via-dpo:[dpo-load-balance:121]
      path:[408] pl-index:242 ip4 weight=1 pref=0 recursive:  oper-flags:resolved,
        via 10.0.0.61 in fib:0 via-fib:128 via-dpo:[dpo-load-balance:129]
      path:[409] pl-index:242 ip4 weight=1 pref=0 recursive:  oper-flags:resolved,
        via 10.0.0.63 in fib:0 via-fib:137 via-dpo:[dpo-load-balance:138]

  default-route refs:1 entry-flags:drop, src-flags:added,
    path-list:[0] locks:1 flags:drop, uPRF-list:0 len:0 itfs:[]
      path:[0] pl-index:0 ip4 weight=1 pref=0 special:  cfg-flags:drop,
        [@0]: dpo-drop ip4

 forwarding:   unicast-ip4-chain
  [@0]: dpo-load-balance: [proto:ip4 index:1 buckets:4 uRPF:168 to:[0:0]]
    [0] [@13]: dpo-load-balance: [proto:ip4 index:112 buckets:1 uRPF:116 to:[0:0]]
          [0] [@5]: ipv4 via 10.0.0.57 BondEthernet101: mtu:9100 next:38 flags:[] 3e9050e769a12259d0d519a90800
    [1] [@13]: dpo-load-balance: [proto:ip4 index:121 buckets:1 uRPF:125 to:[0:0]]
          [0] [@5]: ipv4 via 10.0.0.59 BondEthernet102: mtu:9100 next:39 flags:[] 06b48ba124242259d0d519a90800
    [2] [@13]: dpo-load-balance: [proto:ip4 index:129 buckets:1 uRPF:133 to:[0:0]]
          [0] [@5]: ipv4 via 10.0.0.61 BondEthernet103: mtu:9100 next:40 flags:[] 12390ac1a90c2259d0d519a90800
    [3] [@13]: dpo-load-balance: [proto:ip4 index:138 buckets:1 uRPF:142 to:[0:0]]
          [0] [@5]: ipv4 via 10.0.0.63 BondEthernet104: mtu:9100 next:41 flags:[] 663457500c622259d0d519a90800
```