### PR TITLE
[vpp] Allow routes to override Class E drop

### DIFF
--- a/vppbld/patches/0010-ip4-fib-allow-class-e-route-override.patch
+++ b/vppbld/patches/0010-ip4-fib-allow-class-e-route-override.patch
@@ -1,0 +1,18 @@
+diff --git a/src/vnet/fib/ip4_fib.c b/src/vnet/fib/ip4_fib.c
+index 27f23497f..9d5e5331a 100644
+--- a/src/vnet/fib/ip4_fib.c
++++ b/src/vnet/fib/ip4_fib.c
+@@ -59,7 +59,12 @@ static const ip4_fib_table_special_prefix_t ip4_specials[] = {
+ 	    .fp_len   = 4,
+ 	    .fp_proto = FIB_PROTOCOL_IP4,
+ 	},
+-	.ift_source = FIB_SOURCE_SPECIAL,
++	/*
++	 * SONiC VPP uses Class E destinations in dataplane tests and should
++	 * honor explicit/default routes for them instead of forcing a
++	 * platform-only drop.
++	 */
++	.ift_source = FIB_SOURCE_DEFAULT_ROUTE,
+ 	.ift_flag   = FIB_ENTRY_FLAG_DROP,
+ 
+     },

--- a/vppbld/patches/series
+++ b/vppbld/patches/series
@@ -17,3 +17,5 @@
 0008-bond-drop-stats-track-original-member-interface.patch
 # 9. Add ipip mp2p tunnel
 0009-ipip-add-mp2p-ipip-tunnel.patch
+# 10. Allow SONiC routes to override VPP's Class E default drop
+0010-ip4-fib-allow-class-e-route-override.patch


### PR DESCRIPTION
#### Why I did it
SONiC VPP currently inherits upstream VPP's hard drop for 240.0.0.0/4 via `FIB_SOURCE_SPECIAL`. That source cannot be overridden by normal route programming, so VPP drops Class E destinations even when SONiC has an explicit/default route covering them. This breaks parity with other ASIC platforms and reproduces in `test_decap` traffic that uses 240.0.0.0/4 destinations.

#### How I did it
- Add a VPP patch that changes only the 240.0.0.0/4 default drop source from `FIB_SOURCE_SPECIAL` to `FIB_SOURCE_DEFAULT_ROUTE`.
- Leave multicast 224.0.0.0/4 as `FIB_SOURCE_SPECIAL` so multicast drop behavior is unchanged.
- Register the patch in `vppbld/patches/series`.

#### How I verified it
- `git diff --check`
- Verified the new patch applies cleanly to the pinned FD.io VPP source file from `vppbld/vpp_version` (`src/vnet/fib/ip4_fib.c`).

Fixes sonic-net/sonic-buildimage#27345
