### PR TITLE
vppbld: bump VPP_VERSION 0.3 -> 0.4 to invalidate stale buildkite cache

### DIFF
--- a/rules/vpp.mk
+++ b/rules/vpp.mk
@@ -1,7 +1,13 @@
 # libvpp package
 
 VPP_VERSION_BASE = 2510
-VPP_VERSION = $(VPP_VERSION_BASE)-0.3
+# Bump the minor suffix whenever vppbld/patches/series or any patch file
+# under vppbld/patches/*.patch changes content. The VPP_VERSION_SONIC string
+# is the cache key used by vppbld/Makefile to fetch pre-built debs from
+# https://packages.buildkite.com/sonic-vpp/vpp; if the suffix isn't bumped,
+# downstream sonic-buildimage builds will silently pull stale debs that
+# pre-date the new patch series and end up with VPP/SAI CRC drift.
+VPP_VERSION = $(VPP_VERSION_BASE)-0.4
 VPP_VERSION_SONIC = $(VPP_VERSION)+b1sonic1
 VPP_SRC_PATH = platform/vpp/vppbld
 


### PR DESCRIPTION
PR #234 added vppbld/patches/0011-sonic-inner-aware-flow-hash.patch (introducing BOND_API_LB_ALGO_L34_INNER = 6 and the inner-aware ECMP/LAG hash) but did not bump VPP_VERSION. The vppbld/Makefile keys its cache lookup on VPP_VERSION_SONIC, so downstream sonic-buildimage builds keep pulling the 2026-04-15 0.3+b1sonic1 debs from buildkite -- which were built before patch 0011 existed. As soon as the matching sairedis (PR #1896) lands and starts sending lb=6 to bond_create, the stale VPP rejects the algo, no BondEthernets are created, and all LAG-side BGP sessions stay in Active/Connect (failure visible in sonic-buildimage PR #27621 CI).

Bump the minor suffix to 0.4 to invalidate the cache; downstream builds will fall back to build_locally until buildkite is repopulated for 0.4. Add an inline comment documenting the cache-key convention so the next patch contributor does not repeat the miss.