### PR TITLE
syncd-vpp: keep --privileged

### DIFF
--- a/rules/docker-syncd-vpp.mk
+++ b/rules/docker-syncd-vpp.mk
@@ -44,5 +44,6 @@ $(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(SYNCD_VS_DBG) \
 $(DOCKER_SYNCD_BASE)_VERSION = 1.0.0
 $(DOCKER_SYNCD_BASE)_PACKAGE_NAME = syncd
 
+$(DOCKER_SYNCD_BASE)_RUN_OPT += --privileged
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /dev/hugepages:/dev/hugepages


### PR DESCRIPTION
A companion PR to sonic-net/sonic-buildimage#27522 removes `--privileged` from `$(DOCKER_SYNCD_BASE)_RUN_OPT` in all syncd template mk files, replacing it with specific capabilities (`--cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN`).

docker-syncd-vpp inherits from the bookworm template, so it would lose `--privileged` as a side effect. Since docker-syncd-vpp is not used in production and VPP testing environments depend on full device access, this PR explicitly re-adds `--privileged` in the platform mk file to preserve the existing behavior.