### PR TITLE
[vpp] add `no-class-e-drop` to the vpp startup config

### DIFF
--- a/docker-sonic-vpp/conf/startup.conf.tmpl
+++ b/docker-sonic-vpp/conf/startup.conf.tmpl
@@ -69,6 +69,10 @@ l3fib {
 	ip4-mtrie-pool-size 256K
 }
 
+ip {
+	no-class-e-drop
+}
+
 ip6 {
 	heap-size 128M
 }

--- a/docker-syncd-vpp/conf/startup.conf.tmpl
+++ b/docker-syncd-vpp/conf/startup.conf.tmpl
@@ -69,6 +69,10 @@ l3fib {
 	ip4-mtrie-pool-size 256K
 }
 
+ip {
+	no-class-e-drop
+}
+
 ip6 {
 	heap-size 128M
 }


### PR DESCRIPTION
* Microsoft ADO (number only): 38209399

As the subject, this is to enable the new flag per PR: https://github.com/sonic-net/sonic-platform-vpp/pull/238.

After this PR, the route to the class e subnet is using the default one.
```
vpp# show ip fib table 0 240.0.0.0/4
ipv4-VRF:0, fib_index:0, flow hash:[src dst sport dport proto ] epoch:0 flags:none locks:[adjacency:1, recursive-resolution:8, default-route:1, ]
0.0.0.0/0 fib:0 index:0 locks:3
  API refs:1 src-flags:added,contributing,active,
    path-list:[265] locks:12798 flags:shared,popular, uPRF-list:191 len:4 itfs:[65, 66, 67, 68, ]
      path:[429] pl-index:265 ip4 weight=1 pref=0 recursive:  oper-flags:resolved,
        via 10.0.0.57 in fib:0 via-fib:127 via-dpo:[dpo-load-balance:135]
      path:[430] pl-index:265 ip4 weight=1 pref=0 recursive:  oper-flags:resolved,
        via 10.0.0.59 in fib:0 via-fib:142 via-dpo:[dpo-load-balance:143]
      path:[431] pl-index:265 ip4 weight=1 pref=0 recursive:  oper-flags:resolved,
        via 10.0.0.61 in fib:0 via-fib:150 via-dpo:[dpo-load-balance:151]
      path:[432] pl-index:265 ip4 weight=1 pref=0 recursive:  oper-flags:resolved,
        via 10.0.0.63 in fib:0 via-fib:159 via-dpo:[dpo-load-balance:160]

  default-route refs:1 entry-flags:drop, src-flags:added,
    path-list:[0] locks:1 flags:drop, uPRF-list:0 len:0 itfs:[]
      path:[0] pl-index:0 ip4 weight=1 pref=0 special:  cfg-flags:drop,
        [@0]: dpo-drop ip4

 forwarding:   unicast-ip4-chain
  [@0]: dpo-load-balance: [proto:ip4 index:1 buckets:4 uRPF:191 to:[0:0]]
    [0] [@13]: dpo-load-balance: [proto:ip4 index:135 buckets:1 uRPF:140 to:[0:0]]
          [0] [@5]: ipv4 via 10.0.0.57 BondEthernet101: mtu:9100 next:38 flags:[] 3e9050e769a12259d0d519a90800
    [1] [@13]: dpo-load-balance: [proto:ip4 index:143 buckets:1 uRPF:148 to:[0:0]]
          [0] [@5]: ipv4 via 10.0.0.59 BondEthernet102: mtu:9100 next:39 flags:[] 06b48ba124242259d0d519a90800
    [2] [@13]: dpo-load-balance: [proto:ip4 index:151 buckets:1 uRPF:156 to:[0:0]]
          [0] [@5]: ipv4 via 10.0.0.61 BondEthernet103: mtu:9100 next:40 flags:[] 12390ac1a90c2259d0d519a90800
    [3] [@13]: dpo-load-balance: [proto:ip4 index:160 buckets:1 uRPF:165 to:[0:0]]
          [0] [@5]: ipv4 via 10.0.0.63 BondEthernet104: mtu:9100 next:41 flags:[] 663457500c622259d0d519a90800
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>
