### PR TITLE
[ci] enable PR checker trigger for release branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,12 +5,14 @@
 
 pr:
 - master
+- 202???
 
 trigger:
   batch: true
   branches:
     include:
     - master
+    - 202???
 
 pool:
   vmImage: ubuntu-latest


### PR DESCRIPTION
### Approach
#### What is the motivation for this PR?
The Azure Pipelines PR checker for sonic-dash-ha only triggered on PRs targeting the master branch. PRs raised against release branches (e.g. 202605) did not run the PR validation pipeline, leaving release-branch changes unverified.
#### How did you do it?
Added the 202??? branch pattern to the pr.branches.include list so the PR checker also triggers for release branches.