### PR TITLE
[ci] switch from Azure hosted agent pool to sonicso1ES-amd64 to fix no space left issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,7 @@ trigger:
     - master
     - 202???
 
-pool:
-  vmImage: ubuntu-latest
+pool: sonicso1ES-amd64
 
 schedules:
 - cron: "0 8 * * *"


### PR DESCRIPTION
Change the build jobs to run on the `sonicso1ES-amd64` 1ES hosted pool instead of the Microsoft-hosted `ubuntu-latest` image.

The  amd64-trixie  job was failing during the VPP external-deps (DPDK) build because the hosted agent ran out of disk while stripping debug symbols:
```
objcopy: .../vpp-ext-deps/dbgsym-root/.../.debug[.debug_loclists]: No space left on device
dh_strip: error: objcopy --only-keep-debug ... returned exit code 1
make[1]: *** [Makefile:840: install-ext-deps] Error 2
```
The `ubuntu-latest` agent has only ~14 GB free, which isn't enough for the VPP + DPDK build with debug symbols (larger on trixie due to its DWARF 5 toolchain). The `sonicso1ES-amd64` pool provides much more headroom: 1 TB Premium data disk + ~150 GB resource volume

