### PR TITLE
Pass FIB suppression flag to orchagent from CONFIG_DB

### DIFF
--- a/docker-sonic-vpp/orchagent.sh
+++ b/docker-sonic-vpp/orchagent.sh
@@ -32,6 +32,12 @@ if [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "
 fi
 
+# Pass FIB suppression flag when enabled in CONFIG_DB
+SUPPRESS_FIB_CONFIG=$(sonic-cfggen -d -v "DEVICE_METADATA['localhost'].get('suppress-fib-pending', '')")
+if [ "$SUPPRESS_FIB_CONFIG" == "enabled" ]; then
+    ORCHAGENT_ARGS+="-F "
+fi
+
 # Set mac address
 ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
 


### PR DESCRIPTION
## Summary
- Read `suppress-fib-pending` from CONFIG_DB in `docker-sonic-vpp/orchagent.sh` and pass `-F` to orchagent when enabled
- Matches the logic added in sonic-buildimage PR #26151 for `docker-orchagent` and `docker-sonic-vs`

## Test plan
- [ ] Build sonic-vpp image with `suppress-fib-pending` enabled in CONFIG_DB
- [ ] Verify orchagent starts with `-F` flag after swss restart or config reload
- [ ] Verify APPL_STATE_DB and pub/sub behavior when FIB suppression is enabled/disabled