### PR TITLE
Bump up vpp version

### DIFF
--- a/rules/vpp.mk
+++ b/rules/vpp.mk
@@ -7,7 +7,7 @@ VPP_VERSION_BASE = 2606
 # https://packages.buildkite.com/sonic-vpp/vpp; if the suffix isn't bumped,
 # downstream sonic-buildimage builds will silently pull stale debs that
 # pre-date the new patch series and end up with VPP/SAI CRC drift.
-VPP_VERSION = $(VPP_VERSION_BASE)-0.4
+VPP_VERSION = $(VPP_VERSION_BASE)-0.5
 VPP_VERSION_SONIC = $(VPP_VERSION)+b1sonic1
 VPP_SRC_PATH = platform/vpp/vppbld
 


### PR DESCRIPTION
### why
bump up vpp version to test vpp fresh build impact to sonic-buildimage build time

### what this PR does
Bump up vpp version