### PR TITLE
fix(vpp): backport VPP 2606-0.4 to 202605

### DIFF
--- a/rules/vpp.mk
+++ b/rules/vpp.mk
@@ -7,7 +7,7 @@ VPP_VERSION_BASE = 2606
 # https://packages.buildkite.com/sonic-vpp/vpp; if the suffix isn't bumped,
 # downstream sonic-buildimage builds will silently pull stale debs that
 # pre-date the new patch series and end up with VPP/SAI CRC drift.
-VPP_VERSION = $(VPP_VERSION_BASE)-0.2
+VPP_VERSION = $(VPP_VERSION_BASE)-0.4
 VPP_VERSION_SONIC = $(VPP_VERSION)+b1sonic1
 VPP_SRC_PATH = platform/vpp/vppbld
 


### PR DESCRIPTION
## Summary

Backport the VPP build update from upstream PR #271 to the `202605` release branch.

Original PR: https://github.com/sonic-net/sonic-platform-vpp/pull/271

## Conflict resolution

The source branch advanced from `2606-0.3` to `2606-0.4`, while `202605` established its Trixie package line at `2606-0.2`. The conflict is resolved by setting the release branch's existing `VPP_VERSION` expression to `$(VPP_VERSION_BASE)-0.4`, preserving its `2606` base and `+b1sonic1` package naming convention.

## Validation

- `git diff --check`
- Confirmed no unresolved conflict markers
- Inspected the exact one-line version diff and verified the resolved suffix is `0.4`
- `make -s -n -C vppbld repo_clone VPP_VERSION_SONIC=2606-0.4+b1sonic1`
- Existing 202605 functional validation: https://github.com/sonic-net/sonic-buildimage/pull/29067