### PR TITLE
[vpp][acl] do not count policy denies as interface drops

### DIFF
--- a/rules/vpp.mk
+++ b/rules/vpp.mk
@@ -7,7 +7,7 @@ VPP_VERSION_BASE = 2606
 # https://packages.buildkite.com/sonic-vpp/vpp; if the suffix isn't bumped,
 # downstream sonic-buildimage builds will silently pull stale debs that
 # pre-date the new patch series and end up with VPP/SAI CRC drift.
-VPP_VERSION = $(VPP_VERSION_BASE)-0.6
+VPP_VERSION = $(VPP_VERSION_BASE)-0.7
 VPP_VERSION_SONIC = $(VPP_VERSION)+b1sonic1
 VPP_SRC_PATH = platform/vpp/vppbld
 

--- a/vppbld/patches/0019-acl-do-not-count-policy-denies-as-interface-drops.patch
+++ b/vppbld/patches/0019-acl-do-not-count-policy-denies-as-interface-drops.patch
@@ -1,0 +1,166 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Longxiang Lyu <lolv@microsoft.com>
+Date: Tue, 1 Sep 2026 12:30:00 +0000
+Subject: [PATCH] acl: do not count policy denies as interface drops
+
+An ACL deny is an intentional forwarding decision, but VPP terminates it
+at the generic "error-drop" node, and error-drop charges every packet it
+frees to the ingress interface's drop counter.  That counter is exported
+as /if/drops, which saivpp maps to SAI_PORT_STAT_IF_IN_DISCARDS and SONiC
+renders as RX_DRP.
+
+The result is that a port doing exactly what it was configured to do
+looks broken.  On a dual-ToR the standby mux ports carry a deny ACL, so a
+healthy standby port reports something like
+
+    Ethernet16   RX_OK 5,769   RX_DRP 5,706
+
+i.e. a ~99% discard rate that will page an operator.  Real hardware does
+not behave this way: an ACL deny increments the ACL rule counter, not
+ifInDiscards.  RFC 1213 defines ifInDiscards as packets discarded despite
+"no errors ... to prevent their being deliverable", which is a resource
+condition, not a policy decision.
+
+Add a VNET_BUFFER_F_POLICY_DROP buffer flag.  The ACL plugin sets it when
+a packet is denied by the policy itself, and interface_drop_punt() then
+excludes those packets from the interface drop/punt counter.  Everything
+else is unchanged: the per-node "ACL deny packets" error counter, the
+per-ACE counters behind "show acl-plugin acl", packet tracing and buffer
+freeing all behave exactly as before, so the drops remain fully visible
+to an operator via "show errors".
+
+A deny forced by session-table exhaustion carries ACL_TOO_MANY_SESSIONS
+rather than ACL_DROP and is deliberately left unflagged: that one is a
+genuine resource discard and belongs in the interface counter.
+
+Signed-off-by: Longxiang Lyu <lolv@microsoft.com>
+---
+diff --git a/src/plugins/acl/dataplane_node.c b/src/plugins/acl/dataplane_node.c
+index 471228726..9465c8d64 100644
+--- a/src/plugins/acl/dataplane_node.c
++++ b/src/plugins/acl/dataplane_node.c
+@@ -548,6 +548,17 @@ acl_fa_inner_node_fn (vlib_main_t * vm,
+ 	    vnet_feature_next_u16 (&next[0], b[0]);
+ 	    /* if the action is not deny - then use that next */
+ 	    next[0] = action ? next[0] : 0;
++
++	    /*
++	     * A deny that came from the policy itself is an intentional
++	     * drop, so tell error-drop not to charge it to the interface
++	     * drop counter.  A deny forced by session table exhaustion
++	     * carries ACL_TOO_MANY_SESSIONS instead and is deliberately
++	     * left unflagged: that one is a genuine resource discard.
++	     */
++	    if (PREDICT_FALSE (0 == action)
++		&& b[0]->error == error_node->errors[ACL_FA_ERROR_ACL_DROP])
++	      b[0]->flags |= VNET_BUFFER_F_POLICY_DROP;
+ 	  }
+ 
+ 	  if (node_trace_on)	// PREDICT_FALSE (node->flags & VLIB_NODE_FLAG_TRACE))
+diff --git a/src/vnet/buffer.h b/src/vnet/buffer.h
+--- a/src/vnet/buffer.h
++++ b/src/vnet/buffer.h
+@@ -33,15 +33,24 @@
+   _ (16, IS_DVR, "dvr", 1)                                                    \
+   _ (17, QOS_DATA_VALID, "qos-data-valid", 0)                                 \
+   _ (18, GSO, "gso", 0)                                                       \
+-  _ (19, AVAIL1, "avail1", 1)                                                 \
+-  _ (20, AVAIL2, "avail2", 1)                                                 \
+-  _ (21, AVAIL3, "avail3", 1)                                                 \
+-  _ (22, AVAIL4, "avail4", 1)                                                 \
+-  _ (23, AVAIL5, "avail5", 1)                                                 \
+-  _ (24, AVAIL6, "avail6", 1)                                                 \
+-  _ (25, AVAIL7, "avail7", 1)                                                 \
+-  _ (26, AVAIL8, "avail8", 1)                                                 \
+-  _ (27, AVAIL9, "avail9", 1)
++  _ (19, POLICY_DROP, "policy-drop", 1)                                       \
++  _ (20, AVAIL1, "avail1", 1)                                                 \
++  _ (21, AVAIL2, "avail2", 1)                                                 \
++  _ (22, AVAIL3, "avail3", 1)                                                 \
++  _ (23, AVAIL4, "avail4", 1)                                                 \
++  _ (24, AVAIL5, "avail5", 1)                                                 \
++  _ (25, AVAIL6, "avail6", 1)                                                 \
++  _ (26, AVAIL7, "avail7", 1)                                                 \
++  _ (27, AVAIL8, "avail8", 1)
++
++/*
++ * VNET_BUFFER_F_POLICY_DROP marks a buffer that is being dropped on purpose
++ * by a forwarding policy (today: an ACL deny).  error-drop still counts the
++ * per-node error and frees the buffer as usual, but does not charge the
++ * drop to the ingress interface's drop counter: a policy deny is not an
++ * interface discard.  Drops caused by a lack of resources must NOT set this
++ * flag - those are genuine discards and belong in the interface counter.
++ */
+ 
+ /*
+  * Please allocate the FIRST available bit, redefine
+@@ -52,7 +61,7 @@
+ #define VNET_BUFFER_FLAGS_ALL_AVAIL                                           \
+   (VNET_BUFFER_F_AVAIL1 | VNET_BUFFER_F_AVAIL2 | VNET_BUFFER_F_AVAIL3 |       \
+    VNET_BUFFER_F_AVAIL4 | VNET_BUFFER_F_AVAIL5 | VNET_BUFFER_F_AVAIL6 |       \
+-   VNET_BUFFER_F_AVAIL7 | VNET_BUFFER_F_AVAIL8 | VNET_BUFFER_F_AVAIL9)
++   VNET_BUFFER_F_AVAIL7 | VNET_BUFFER_F_AVAIL8)
+ 
+ #define VNET_BUFFER_FLAGS_VLAN_BITS \
+   (VNET_BUFFER_F_VLAN_1_DEEP | VNET_BUFFER_F_VLAN_2_DEEP)
+diff --git a/src/vnet/interface_output.c b/src/vnet/interface_output.c
+--- a/src/vnet/interface_output.c
++++ b/src/vnet/interface_output.c
+@@ -1040,6 +1040,37 @@
+       count = clib_count_equal_u32 (sw_if_index, n_left);
+       n_left -= count;
+ 
++      /*
++       * Walk the block once to (a) discount intentional policy drops, which
++       * must not look like interface discards, and (b) for packets whose RX
++       * sw_if_index was rewritten (e.g. by bond-input), also charge the
++       * original member interface.
++       */
++      {
++	u32 n_policy = 0;
++
++	for (u32 j = 0; j < count; j++)
++	  {
++	    vlib_buffer_t *ob = bufs[off + j];
++	    u32 orig;
++
++	    if (ob->flags & VNET_BUFFER_F_POLICY_DROP)
++	      {
++		n_policy++;
++		continue;
++	      }
++
++	    orig = vnet_buffer2 (ob)->orig_rx_sw_if_index;
++	    if (orig && orig != sw_if_index[0])
++	      vlib_increment_simple_counter (cm, thread_index, orig, 1);
++	  }
++
++	count -= n_policy;
++      }
++
++      if (0 == count)
++	continue;
++
+       vlib_increment_simple_counter (cm, thread_index, sw_if_index[0], count);
+ 
+       /* Increment super-interface drop/punt counters for
+@@ -1048,19 +1079,6 @@
+       if (sw_if0->sup_sw_if_index != sw_if_index[0])
+ 	vlib_increment_simple_counter
+ 	  (cm, thread_index, sw_if0->sup_sw_if_index, count);
+-
+-      /* Also count against the original member interface if the
+-         RX sw_if_index was rewritten (e.g. by bond-input). */
+-      {
+-	u32 orig_off = frame->n_vectors - n_left - count;
+-	for (u32 j = 0; j < count; j++)
+-	  {
+-	    vlib_buffer_t *ob = bufs[orig_off + j];
+-	    u32 orig = vnet_buffer2 (ob)->orig_rx_sw_if_index;
+-	    if (orig && orig != sw_if_index[0])
+-	      vlib_increment_simple_counter (cm, thread_index, orig, 1);
+-	  }
+-      }
+     }
+ 
+   vnet_interface_main_t *im = &vnm->interface_main;

--- a/vppbld/patches/series
+++ b/vppbld/patches/series
@@ -39,3 +39,9 @@
 #     rule be scoped to specific ports, so SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS
 #     no longer has to be silently dropped by the SAI layer.
 0018-acl-match-on-ingress-interface.patch
+# 19. acl: an ACL deny is an intentional forwarding decision, not an
+#     interface discard.  Flag denied buffers so error-drop keeps counting
+#     the per-node/per-ACE error but stops charging them to /if/drops,
+#     which SONiC surfaces as RX_DRP.  Without this a standby dual-ToR mux
+#     port reports a ~99% discard rate while working correctly.
+0019-acl-do-not-count-policy-denies-as-interface-drops.patch


### PR DESCRIPTION
### What

An ACL deny is an intentional forwarding decision, not an interface discard, but
today the deny path sends the buffer to `error-drop`, which charges it to the
ingress interface's drop counter (`/if/drops`). SONiC exports that counter as
`SAI_PORT_STAT_IF_IN_DISCARDS` and displays it as `RX_DRP`, so a port doing
exactly what it was configured to do reports a large and growing discard count.

This adds `VNET_BUFFER_F_POLICY_DROP` and stops charging policy denies to the
interface drop counter, while keeping them fully visible as per-node/per-ACE
errors.

### Why

This is most visible on a **dual-ToR standby mux port**, where the standby ToR is
*supposed* to drop the traffic it receives from the server. The port reports a
~99% `RX_DRP` rate while forwarding perfectly correctly:

```
Port Ethernet16 on standby ToR vlab-vpp-04 has RX_DRP increment of 5706
which exceeds threshold of 10 (before=0, after=5706)
```

> **Correction (2026-09-04).** An earlier version of this description claimed
> "SONiC itself already treats ACL drops as `RX_ERR`, not `RX_DRP`", and leaned on
> RFC 1213 as if it mandated the change. **Both were wrong**, and the section below
> has been rewritten. Thanks to @nhegde-microsoft and @aaronber0614 for catching it.
> The corrected justification is stronger, not weaker — see
> [this comment](https://github.com/sonic-net/sonic-platform-vpp/pull/280#issuecomment-5528695663)
> for the discussion.

The counter semantics are the problem, not the drops themselves.

**Where SONiC expects an ACL drop to be counted.** Upstream `sonic-mgmt` states
this directly. For `discard_group == "ACL"`, `tests/drop_packets/test_drop_counters.py`
asserts the per-ACE ACL rule counter increments, and then — on any platform not
listed as having *combined* counters — asserts that **neither** `RX_DRP` **nor**
`RX_ERR` moved:

```python
if acl_drops != pkt_number:
    pytest.fail(...)                      # per-ACE counter MUST increment
if not COMBINED_ACL_DROP_COUNTER:
    executor.submit(ensure_no_l3_and_l2_drops, duthost, packets_count=pkt_number)
```

So an ACL drop belongs in the per-ACE counter — not `RX_ERR`, and not `RX_DRP`.

**VPP is already declared as such a platform.** `tests/drop_packets/combined_drop_counters.yml`
lists the platforms where ACL and L2 drop counters legitimately *are* combined:

```yaml
acl_l2:
    - "x86_64-mlnx"
    - "x86_64-dell.*"
    - "x86_64-arista.*"
    - "x86_64-cel_seastone.*"
    - "x86_64-nokia.*"
```

`x86_64-kvm_x86_64-r0` (VPP) appears in that file's `l2_l3` list but **deliberately
not** in `acl_l2` — added by @AkeelAli in
[sonic-mgmt#24031](https://github.com/sonic-net/sonic-mgmt/pull/24031)
("Enable test_drop_counters.py on Sonic-VPP"). Upstream has therefore already
declared that on VPP an ACL drop must not land in the L2/`RX_DRP` counter. Today
VPP contradicts that declaration; this patch makes it conform.

**And the dual-ToR case was called out explicitly.** The test that fails here was
added by a third party in
[sonic-mgmt#23577](https://github.com/sonic-net/sonic-mgmt/pull/23577), whose
description reads:

> In case of active-standby configuration, an DROP ACL is attached to the standby
> port. This ACL drop is intentional and should not raise the RX_DROPS. RX_DROP
> count increment can raise alarms in alerting systems.

**On RFC 1213.** For completeness, the RFC does *not* settle this. `ifInDiscards`
is "the number of inbound packets which were chosen to be discarded even though no
errors had been detected...  **One possible reason** ... **could be** to free up
buffer space" — buffer exhaustion is an example, not the definition. A strict
reading leaves `RX_DRP` defensible for a policy drop. The justification for this
change is the SONiC-level convention above, not the RFC.

### How

Three small changes:

1. **`src/vnet/buffer.h`** — allocate `VNET_BUFFER_F_POLICY_DROP` on bit 19, the
   first free bit. Per the in-tree convention comment, `AVAIL1..AVAIL9` are
   redefined as `AVAIL1..AVAIL8` and `VNET_BUFFER_FLAGS_ALL_AVAIL` is updated.
2. **`src/plugins/acl/dataplane_node.c`** — set the flag at the single ACL deny
   choke point in `acl_fa_inner_node_fn()`.
3. **`src/vnet/interface_output.c`** — `interface_drop_punt()` discounts flagged
   buffers from the interface drop counter. It reuses the existing per-buffer
   loop added by patch 0008, so there is no new pass over the frame.

The flag is set **only** for `ACL_FA_ERROR_ACL_DROP`. Drops caused by a lack of
resources, such as `ACL_FA_ERROR_ACL_TOO_MANY_SESSIONS`, are genuine discards and
continue to increment the interface counter.

Denies remain fully observable — this suppresses one counter, not the visibility:

```
11398   acl-plugin-in-ip4-l2    ACL deny packets    error
```

### Verification

Built as VPP `2606-0.6` and deployed to a KVM dual-ToR testbed
(`vms-kvm-dual-vpp-t0-1`, `vlab-vpp-03`/`vlab-vpp-04`).

`dualtor_io/test_normal_op.py::test_upstream_standby_rx_drop_check` **passes**:

```
test_normal_op.py:467  Port Ethernet40 on standby ToR vlab-vpp-04:
                       RX_DRP diff=0 (before=0, after=0), threshold=10
```

Raw port counters on the standby mux port confirm the mechanism rather than just
the outcome — 5762 packets received and denied, none counted as interface drops:

| | Before | After |
|---|---|---|
| `RX_OK` | 5706 | 5,762 |
| `RX_DRP` | +5706 | **0** |

The full patch series (`0001`–`0017` plus this one) was also verified to apply
cleanly with `git apply` against pinned VPP commit `3f9e978d`.

> **On the version label.** The testbed run above was built as `2606-0.6`. The
> branch now sets `2606-0.7`, because #278 merged first and published `0.6` for
> patch 0018. The **patch content is byte-identical** to what was tested — only
> `series` and `rules/vpp.mk` changed in the rebase — so no re-test is implied.

### Notes for reviewers

- **Scope of the suppression.** This applies to *all* ACL denies, including
  operator-configured DATAACL rules, not just the dual-ToR case. That matches the
  upstream `discard_group == "ACL"` expectation above, which is not dual-ToR
  specific, and avoids the incoherent rule that a DATAACL deny would be an
  interface discard on a normal port but not on a mux port. It is still a
  deliberate semantic change and worth a second opinion.
- **Nothing under-reports as a result.** SONiC detects ACL drops via the `ACL_ANY`
  `DEBUG_COUNTER` and the per-ACE `acl_facts` `packets_count`, both untouched here.
  I found no consumer of `SAI_PORT_STAT_IF_IN_DISCARDS` / `RX_DRP` in `monit` or
  `sonic-swss-common` that keys on ACL denies.
- **Bit 19 reallocation** touches a shared header. It follows the documented
  convention in `buffer.h` exactly, and `avail9` is confirmed gone from the built
  `libvnet.so`.
- This was split out of #278 (ACL `IN_PORTS` support), where it originated. The
  two changes are independent — they touch **disjoint files** — and #278 will be
  rebased on top of whichever lands first.