### PR TITLE
[vpp] reduce syncd-vpp dataplane workers from 2 to 1

### DIFF
--- a/docker-syncd-vpp/conf/startup.conf.tmpl
+++ b/docker-syncd-vpp/conf/startup.conf.tmpl
@@ -102,6 +102,7 @@ cpu {
 	## Specify a number of workers to be created
 	## Workers are pinned to N consecutive CPU cores while skipping "skip-cores" CPU core(s)
 	## and main thread's CPU core
+	## Always rewritten by vpp_init.sh from $VPP_WORKERS (default 1; 0 = forward on vpp_main)
 	workers 1
 
 	## Set scheduling policy and priority of main and worker threads

--- a/docker-syncd-vpp/conf/startup.conf.tmpl
+++ b/docker-syncd-vpp/conf/startup.conf.tmpl
@@ -102,7 +102,7 @@ cpu {
 	## Specify a number of workers to be created
 	## Workers are pinned to N consecutive CPU cores while skipping "skip-cores" CPU core(s)
 	## and main thread's CPU core
-	## Always rewritten by vpp_init.sh from $VPP_WORKERS (default 1; 0 = forward on vpp_main)
+	## Overridden by vpp_init.sh when $VPP_WORKERS is set (0 = forward on vpp_main)
 	workers 1
 
 	## Set scheduling policy and priority of main and worker threads

--- a/docker-syncd-vpp/conf/startup.conf.tmpl
+++ b/docker-syncd-vpp/conf/startup.conf.tmpl
@@ -102,7 +102,7 @@ cpu {
 	## Specify a number of workers to be created
 	## Workers are pinned to N consecutive CPU cores while skipping "skip-cores" CPU core(s)
 	## and main thread's CPU core
-	workers 2
+	workers 1
 
 	## Set scheduling policy and priority of main and worker threads
 

--- a/docker-syncd-vpp/scripts/vpp_init.sh
+++ b/docker-syncd-vpp/scripts/vpp_init.sh
@@ -51,6 +51,7 @@ cp $STARTUP_TMPL $TMP_FILE || error "Failed to copy template file"
 [ "$DPDK_DISABLE" == "y" ] && sed -i -e 's/plugin dpdk_plugin/#plugin dpdk_plugin/g' $TMP_FILE
 [ "$NO_LINUX_NL" == "y" ] && sed -i -e 's/plugin linux_nl_plugin/#plugin linux_nl_plugin/g' $TMP_FILE
 
+# 0 is allowed: VPP then forwards on vpp_main itself, with no dedicated worker thread.
 VPP_WORKERS=${VPP_WORKERS:=1}
 [[ "$VPP_WORKERS" =~ ^[0-9]+$ ]] || error "VPP_WORKERS must be a non-negative integer, got '$VPP_WORKERS'"
 sed -i -E -e "s/^([[:space:]]*)workers[[:space:]]+[0-9]+/\1workers $VPP_WORKERS/" $TMP_FILE

--- a/docker-syncd-vpp/scripts/vpp_init.sh
+++ b/docker-syncd-vpp/scripts/vpp_init.sh
@@ -51,10 +51,11 @@ cp $STARTUP_TMPL $TMP_FILE || error "Failed to copy template file"
 [ "$DPDK_DISABLE" == "y" ] && sed -i -e 's/plugin dpdk_plugin/#plugin dpdk_plugin/g' $TMP_FILE
 [ "$NO_LINUX_NL" == "y" ] && sed -i -e 's/plugin linux_nl_plugin/#plugin linux_nl_plugin/g' $TMP_FILE
 
-# 0 is allowed: VPP then forwards on vpp_main itself, with no dedicated worker thread.
-VPP_WORKERS=${VPP_WORKERS:=1}
-[[ "$VPP_WORKERS" =~ ^[0-9]+$ ]] || error "VPP_WORKERS must be a non-negative integer, got '$VPP_WORKERS'"
-sed -i -E -e "s/^([[:space:]]*)workers[[:space:]]+[0-9]+/\1workers $VPP_WORKERS/" $TMP_FILE
+if [ "x$VPP_WORKERS" != "x" ]; then
+    # 0 is allowed: VPP then forwards on vpp_main itself, with no dedicated worker thread.
+    [[ "$VPP_WORKERS" =~ ^[0-9]+$ ]] || error "VPP_WORKERS must be a non-negative integer, got '$VPP_WORKERS'"
+    sed -i -E -e "s/^([[:space:]]*)workers[[:space:]]+[0-9]+/\1workers $VPP_WORKERS/" $TMP_FILE
+fi
 
 IDX=0
 upd_startup """dpdk {

--- a/docker-syncd-vpp/scripts/vpp_init.sh
+++ b/docker-syncd-vpp/scripts/vpp_init.sh
@@ -51,6 +51,10 @@ cp $STARTUP_TMPL $TMP_FILE || error "Failed to copy template file"
 [ "$DPDK_DISABLE" == "y" ] && sed -i -e 's/plugin dpdk_plugin/#plugin dpdk_plugin/g' $TMP_FILE
 [ "$NO_LINUX_NL" == "y" ] && sed -i -e 's/plugin linux_nl_plugin/#plugin linux_nl_plugin/g' $TMP_FILE
 
+VPP_WORKERS=${VPP_WORKERS:=1}
+[[ "$VPP_WORKERS" =~ ^[0-9]+$ ]] || error "VPP_WORKERS must be a non-negative integer, got '$VPP_WORKERS'"
+sed -i -E -e "s/^([[:space:]]*)workers[[:space:]]+[0-9]+/\1workers $VPP_WORKERS/" $TMP_FILE
+
 IDX=0
 upd_startup """dpdk {
 	dev default {

--- a/sonic-platform-modules-vpp/files/etc/config-setup/factory-default-hooks.d/10-01-vpp-cfg-init
+++ b/sonic-platform-modules-vpp/files/etc/config-setup/factory-default-hooks.d/10-01-vpp-cfg-init
@@ -79,6 +79,10 @@ function setup_ports_list()
         echo "PERPORT_BUF=$PERPORT_BUF" >> $VPP_ENV_FILE
     fi
 
+    if [ "x$VPP_WORKERS" != "x" ]; then
+        echo "VPP_WORKERS=$VPP_WORKERS" >> $VPP_ENV_FILE
+    fi
+
     if [ "x$SONIC_VPP_SWITCH" != "x" ]; then
         echo "SONIC_VPP_SWITCH=$SONIC_VPP_SWITCH" >> $VPP_ENV_FILE
     fi    

--- a/sonic-platform-modules-vpp/files/etc/config-setup/factory-default-hooks.d/10-01-vpp-cfg-init
+++ b/sonic-platform-modules-vpp/files/etc/config-setup/factory-default-hooks.d/10-01-vpp-cfg-init
@@ -80,6 +80,8 @@ function setup_ports_list()
     fi
 
     if [ "x$VPP_WORKERS" != "x" ]; then
+        # validated here too: syncd_vpp_env is sourced, so anything written to it runs as shell
+        [[ "$VPP_WORKERS" =~ ^[0-9]+$ ]] || error "VPP_WORKERS must be a non-negative integer, got '$VPP_WORKERS'"
         echo "VPP_WORKERS=$VPP_WORKERS" >> $VPP_ENV_FILE
     fi
 


### PR DESCRIPTION
##### Work item tracking
- Microsoft ADO **(number only)**: 39625344


### Why I did it

`docker-syncd-vpp/conf/startup.conf.tmpl` is the startup config `vpp_init.sh` uses on the default boot path (`VPP_CONF_DB` unset), so every SONiC-VPP DUT built from this repo comes up with a main thread plus **two** dataplane workers pinned to dedicated cores.

Every one of those workers busy-polls unconditionally:

- `vlib/file.c:139` skips the epoll sleep whenever any input node is in polling state.
- The `poll-sleep-usec` throttle at `vlib/file.c:122` is guarded by `is_main`, so it can **never** apply to a worker.
- The `bobm` ports are Red Hat virtio (`1af4:1041`) on DPDK `net_virtio`, which supports neither interrupt nor adaptive rx-mode.

So every worker holding a port burns a full core whether or not traffic is flowing, and lowering the worker count is the only lever available.

That sizing is wasteful for the environments this image actually runs in. KVM/virtual testbeds hand the DUT a small number of vCPUs, and pinning three busy-polling threads starves the control plane (syncd, orchagent, bgpd) and makes several DUTs on one host contend for cores.

### How I did it

Drop the default to a single worker — VPP still runs main + 1 worker, so packet processing stays off the main thread, and the freed core goes back to the control plane.

Because a hardcoded count would also apply to deployments that legitimately want more workers, the value is taken from a `VPP_WORKERS` environment variable defaulting to `1`. This follows the existing `PERPORT_BUF` pattern: `vpp_init.sh` rewrites the `workers` line in the generated config, and `10-01-vpp-cfg-init` propagates the variable into `/etc/sonic/vpp/syncd_vpp_env` when set.

`VPP_CONF_DB` is not a substitute — it bypasses DPDK port discovery, `bobm` interface naming, buffer sizing and hugepage setup, so it requires hand-authoring the entire boot config.

No dpdk configuration needs to change alongside this, and the commented-out knobs in the template are left as they are:

- `num-rx-queues` defaults to 1 irrespective of the worker count (`dpdk/device/init.c:313`).
- `num-tx-queues` defaults to `n_vlib_mains`, i.e. workers + 1 (`dpdk/device/init.c:314`), so it follows on its own.
- `buffers-per-numa` is `PERPORT_BUF * SONIC_NUM_PORTS` and the hugepage count is derived from the port count, both independent of the worker count.

In practice the queue knobs are moot on this platform, because the NICs are single-queue and VPP clamps to the device maximum at `init.c:485`:

```
$ docker exec syncd vppctl show hardware-interfaces | grep -E 'rx: queues|tx: queues' | sort | uniq -c
     32     rx: queues 1 (max 1), desc 256 (min 32 max 32768 align 1)
     32     tx: queues 1 (max 1), desc 4096 (min 32 max 32768 align 1)
```

So the effective dpdk queue counts are 1 both before and after. The rx queue reduction measured below comes entirely from the tap interfaces going from two queues to one.

Reducing the worker count also lowers buffer demand rather than raising it, since the tap rx rings halve, so the existing `buffers-per-numa` sizing stays comfortable: the pool runs at roughly 31% utilisation (20375 used of 66297) with a single worker. As a side effect, the single shared tx queue is now contended by two threads instead of three (`queue 0 shared yes thread(s) 0-1`), which slightly reduces tx spinlock pressure.

### How to verify it

Measured on a two-DUT dualtor KVM testbed, 16 logical / 8 physical cores:

| | before | after |
|---|---|---|
| VPP threads per DUT | 3 | 2 |
| VPP CPU per DUT | 282% | **178%** |
| host CPU, both DUTs | 706% | **483%** (2.23 physical cores, −32%) |
| host idle under test | 36% | **51%** |
| host run queue under test | avg 11.0 / max 29 | avg 7.0 / max 12 |
| polling rx queues per DUT | 114 | 73 |
| highest lcore pinned | 3 | 2 (minimum vCPU 4 → 3) |

`test_active_tor_shutdown_bgp_sessions_upstream[active-active]`, which currently fails in CI on this testbed, **passes in 393.30s** with a single worker, and no server sees more than one disruption; the two-worker baseline had 12 of 24 servers disrupted once and one disrupted twice.

Thread placement on a running DUT:

```
$ docker exec syncd vppctl show threads
ID     Name         Type      LWP    lcore  Core  Socket
0      vpp_main               56     2      2     0
1      vpp_wk_0     workers   63     1      1     0
```

The override knob:

```
# unset            -> workers 1   (new default)
# VPP_WORKERS=0    -> workers 0   (forwarding on vpp_main, no worker thread)
# VPP_WORKERS=3    -> workers 3
# VPP_WORKERS=bogus -> rejected at init with a clear error
```


### `VPP_WORKERS=0` is a supported configuration

The override validates as a **non-negative** integer, so `0` is accepted deliberately.
`workers 0` is legal in VPP and means no dedicated worker thread — `vpp_main` does the
forwarding itself. That is the cheapest configuration available, since one thread
busy-polls instead of two, and it is what `docker-sonic-vpp` already ships (its template
leaves `workers` commented out entirely).

It is not the default here because the point of a dedicated worker is to keep packet
processing off the thread that also serves the binary API, CLI and stats, so a busy
control plane cannot stall forwarding. But on a CPU-starved host where that trade is
worth making, `VPP_WORKERS=0` is available and supported rather than an artefact of the
validation regex.

The value is not bounds-checked against available cores — VPP clamps or fails at init if
the count exceeds what the CPU set allows. An operator setting a high override is opting in.
